### PR TITLE
Adjusted the formatting of a TypeofExpression to not have a space after ...

### DIFF
--- a/src/std/d/formatter.d
+++ b/src/std/d/formatter.d
@@ -3375,7 +3375,7 @@ class Formatter(Sink)
         Token return_;
         **/
 
-        put("typeof (");
+        put("typeof(");
         typeofExpr.expression ? format(typeofExpr.expression) : format(typeofExpr.return_);
         put(")");
     }


### PR DESCRIPTION
...the keyword.
