### PR TITLE
Adding default dub gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.dub
+docs.json
+__dummy.html
+*.o
+*.obj


### PR DESCRIPTION
The latest version of dub create this .gitignore on `dub init`
This is especially usefull for git submodules.
