### PR TITLE
Fix parsing debug declarations

### DIFF
--- a/src/std/d/parser.d
+++ b/src/std/d/parser.d
@@ -1833,20 +1833,15 @@ class ClassFive(A, B) : Super if (someTest()) {}}c;
             }
             break;
         case tok!"debug":
-            if (peekIs(tok!"("))
-            {
-                node.conditionalDeclaration = parseConditionalDeclaration();
-                if (node.conditionalDeclaration is null) return null;
-            }
-            else if (peekIs(tok!"="))
+            if (peekIs(tok!"="))
             {
                 node.debugSpecification = parseDebugSpecification();
                 if (node.debugSpecification is null) return null;
             }
             else
             {
-                error(`"=" or "(" expected following "debug"`);
-                return null;
+                node.conditionalDeclaration = parseConditionalDeclaration();
+                if (node.conditionalDeclaration is null) return null;
             }
             break;
         default:


### PR DESCRIPTION
``` d
debug = foo; // ok
debug(cond) import std.stdio; // ok
debug import std.stdio; // [error]: "=" or "(" expected following "debug"
```
