### PR TITLE
Support types starting with dots

### DIFF
--- a/src/std/d/parser.d
+++ b/src/std/d/parser.d
@@ -1806,6 +1806,7 @@ class ClassFive(A, B) : Super if (someTest()) {}}c;
         case tok!"inout":
         case tok!"scope":
         case tok!"typeof":
+        case tok!".":
         mixin (BASIC_TYPE_CASES);
         type:
             Type type = parseType();


### PR DESCRIPTION
``` d
void func()
{
    .Type t;
}
```

Parser tried to parse `.Type t;` as a statement and failed.
