### PR TITLE
Fix DCD debug build

### DIFF
--- a/src/std/d/lexer.d
+++ b/src/std/d/lexer.d
@@ -90,6 +90,10 @@ private enum extraFields = q{
 		if (index > i) return 1;
 		return 0;
 	}
+
+	int opCmp(ref const typeof(this) other) const pure nothrow @safe {
+		return opCmp(other.index);
+	}
 };
 public alias Token = std.lexer.TokenStructure!(IdType, extraFields);
 


### PR DESCRIPTION
Currently DCD debug building fails as it is described in [issue 101](https://github.com/Hackerpilot/DCD/issues/101). 
It seems like assumeSorted requires opCmp operator for Token. Token itself is an alias for std.lexer.TokenStructure!(IdType, extraFields) that has opCmp(size_t i) generated by mixin extraFields (from libdparse/src/std/d/lexer.d +84) but does not have opCmp for Token. 
Actually, I don't know details of TokenStructure so I'm not sure that this operator was implemented correctly, but it fixes compilation.
