### PR TITLE
`protected` members `Formatter` to allow customized derived formatters

### DIFF
--- a/src/std/d/formatter.d
+++ b/src/std/d/formatter.d
@@ -3564,7 +3564,7 @@ class Formatter(Sink)
 
     Sink sink;
 
-private:
+protected:
 
     import std.uni : isWhite;
 


### PR DESCRIPTION
`Formatter` can be derived from but it's not really useful because even
though its public methods can be overriden, the overriding code can't
use private functions like `put()` or variables like `indentLevel`.

I want to override a few members but would prefer to do so without
copying all the code.

This changes all these members to protected. I don't know if any of
these members are such that they must absolutely never be overridden;
such members could then be made `private` and/or `final`.
