### PR TITLE
Use experimental_allocator from dub

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
 	"targetType": "library",
 	"description": "Library for lexing and parsing D source code",
 	"license": "BSL-1.0",
-        "version": "0.3.0-alpha",
-	"importPaths": ["src", "experimental_allocator"],
-	"sourcePaths": ["src", "experimental_allocator"]
+	"dependencies":{
+		"experimental_allocator":"~>0.0.1",
+	}
 }

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -9,10 +9,9 @@ GREEN="\033[32m"
 RED="\033[31m"
 CYAN="\033[36m"
 DMD=${DMD:=dmd}
-ALLOCATOR_SOURCE=$(find ../experimental_allocator/src/std/experimental -name "*.d")
 
 echo -en "Compiling tester... "
-${DMD} tester.d ../src/std/experimental/*.d ../src/dparse/*.d ${ALLOCATOR_SOURCE} -g -I../src/ || exit 1
+${DMD} tester.d ../src/std/experimental/*.d ../src/dparse/*.d -g -I../src/ || exit 1
 echo -e "${GREEN}DONE${NORMAL}"
 
 for i in $PASS_FILES; do
@@ -50,7 +49,7 @@ fi
 
 find . -name "*.lst" | xargs rm -f
 echo -en "Generating coverage reports... "
-${DMD} tester.d -cov ../src/std/experimental/*.d ../src/dparse/*.d  ${ALLOCATOR_SOURCE} -I../src/ || exit 1
+${DMD} tester.d -cov ../src/std/experimental/*.d ../src/dparse/*.d -I../src/ || exit 1
 ./tester $PASS_FILES $FAIL_FILES 2>/dev/null 1>/dev/null
 rm -rf coverage/
 mkdir coverage/


### PR DESCRIPTION
i removed experimental_allocator git submodule because it isn't needed anymore.
Also removed version from dub file because version can be set by tags in github.
