### PR TITLE
[Experiment] Enable CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+# Documentation: https://github.com/codecov/support/wiki/codecov.yml
+codecov:
+coverage:
+  precision: 3
+  round: down
+
+  status:
+    # Learn more at https://codecov.io/docs#yaml_default_commit_status
+    project: true
+    patch: true
+    changes: false
+
+comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/tokens-newlines.txt
 test/tokens.txt
 test/unittests
 dub.selections.json
+*.lst

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,7 @@ d:
   - ldc
 sudo: false
 script:
-  - cd test && ./run_tests.sh
+  - cd test && ./run_tests.sh && cd ..
+  - find test/coverage -type f -exec mv {} . \;
+after_success:
+ - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
In theory that should be all that's needed to get CodeCov reports on the CI status report. 