### PR TITLE
Allow configureable WhitespaceBehavior in getTokensForParser

### DIFF
--- a/src/dparse/lexer.d
+++ b/src/dparse/lexer.d
@@ -384,9 +384,10 @@ public bool isLiteral(IdType type) pure nothrow @safe @nogc
 }
 
 /**
- * Returns: an array of tokens lexed from the given source code to the output range. All
- * whitespace tokens are skipped and comments are attached to the token nearest
- * to them.
+ * Returns: an array of tokens lexed from the given source code to the output range.
+ * Whitespace token are skipped by default, except `WhitespaceBehavior.include`
+ * has been set explicitly.
+ * comments are attached to the token nearest to them.
  */
 const(Token)[] getTokensForParser(ubyte[] sourceCode, LexerConfig config,
     StringCache* cache)

--- a/src/dparse/lexer.d
+++ b/src/dparse/lexer.d
@@ -171,7 +171,7 @@ public struct LexerConfig
 {
     string fileName;
     StringBehavior stringBehavior;
-    WhitespaceBehavior whitespaceBehavior;
+    WhitespaceBehavior whitespaceBehavior = WhitespaceBehavior.skip;
     CommentBehavior commentBehavior = CommentBehavior.intern;
 }
 
@@ -409,7 +409,6 @@ const(Token)[] getTokensForParser(ubyte[] sourceCode, LexerConfig config,
         return CommentType.notDoc;
     }
 
-    config.whitespaceBehavior = WhitespaceBehavior.skip;
     config.commentBehavior = CommentBehavior.noIntern;
 
     auto leadingCommentAppender = appender!(char[])();
@@ -425,6 +424,9 @@ const(Token)[] getTokensForParser(ubyte[] sourceCode, LexerConfig config,
     {
     case tok!"specialTokenSequence":
     case tok!"whitespace":
+        if (config.whitespaceBehavior == WhitespaceBehavior.include)
+            output.put(lexer.front);
+
         lexer.popFront();
         break;
     case tok!"comment":


### PR DESCRIPTION
Needed for https://github.com/dlang-community/D-Scanner/pull/448 and and https://github.com/dlang-community/D-Scanner/pull/450

I am not sure whether this is the best solution as it requires allocation by the user as `const(Token)[]` is 

```d
	tokens = getTokensForParser(code, config, &cache);
	auto tokensC = tokens; // <-- this can be used by the Dscanner checks
	if (config.whitespaceBehavior == WhitespaceBehavior.include)
		tokensC = tokens.filter!(t => t.type != WhitespaceBehavior.include).array;
...
	dparse.parser.parseModule(tokensC, fileName, p, report, ...)
...
```

The parser currently doesn't check for whitespace tokens and imho it would unnecessarily complicate its logic to add checks.