### PR TITLE
Add support for C-style alias declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ script. Running the tests on Windows is not currently supported.
 * [Static array initialization syntax](http://dlang.org/arrays.html#static-init-static). This syntax is ambiguous because it looks like an associative array literal.
 * [Class allocators](http://dlang.org/class.html#allocators). These are deprecated in D2.
 * [Class deallocators](http://dlang.org/class.html#deallocators). These are deprecated in D2.
-* C-style alias syntax. For example: ```alias int F1();```

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -441,7 +441,8 @@ final class AliasDeclaration : ASTNode
 public:
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(storageClasses, type, identifierList, initializers));
+        mixin (visitIfNotNull!(storageClasses, type, identifierList, initializers,
+                               parameters, memberFunctionAttributes));
     }
     mixin OpEquals;
     /** */ StorageClass[] storageClasses;
@@ -449,6 +450,8 @@ public:
     /** */ IdentifierList identifierList;
     /** */ AliasInitializer[] initializers;
     /** */ string comment;
+    /** */ Parameters parameters;
+    /** */ MemberFunctionAttribute[] memberFunctionAttributes;
 }
 
 ///

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -74,6 +74,7 @@ class Parser
      * $(GRAMMAR $(RULEDEF aliasDeclaration):
      *       $(LITERAL 'alias') $(RULE aliasInitializer) $(LPAREN)$(LITERAL ',') $(RULE aliasInitializer)$(RPAREN)* $(LITERAL ';')
      *     | $(LITERAL 'alias') $(RULE storageClass)* $(RULE type) $(RULE identifierList) $(LITERAL ';')
+     *     | $(LITERAL 'alias') $(RULE storageClass)* $(RULE type) $(RULE identifier) $(LITERAL '(') $(RULE parameters) $(LITERAL ')') $(memberFunctionAttribute)* $(LITERAL ';')
      *     ;)
      */
     AliasDeclaration parseAliasDeclaration()
@@ -108,6 +109,15 @@ class Parser
             ownArray(node.storageClasses, storageClasses);
             mixin (parseNodeQ!(`node.type`, `Type`));
             mixin (parseNodeQ!(`node.identifierList`, `IdentifierList`));
+            if (currentIs(tok!"("))
+            {
+                mixin(parseNodeQ!(`node.parameters`, `Parameters`));
+                StackBuffer memberFunctionAttributes;
+                while (moreTokens() && currentIsMemberFunctionAttribute())
+                    if (!memberFunctionAttributes.put(parseMemberFunctionAttribute()))
+                        return null;
+                ownArray(node.memberFunctionAttributes, memberFunctionAttributes);
+            }
         }
         return attachCommentFromSemicolon(node);
     }

--- a/test/pass_files/aliases.d
+++ b/test/pass_files/aliases.d
@@ -16,3 +16,44 @@ struct S
 	int a;
 	alias a this;
 }
+
+// C-style aliases
+alias int GetterType() @property;
+alias int SetterType(int) @property;
+alias string SetterType(int, string) @nogc;
+alias string SetterType(int, string) @safe;
+alias int F1();
+alias @property int F2();
+alias string F3();
+alias nothrow @trusted uint F4();
+alias int F5(Object);
+alias bool F6(Object);
+alias int F1();
+alias int F2() pure nothrow;
+alias int F3() @safe;
+alias int F23() @safe pure nothrow;
+
+// return type covariance
+alias long F4();
+class C {}
+class D : C {}
+alias C F5();
+alias D F6();
+alias typeof(null) F7();
+alias int[] F8();
+alias int* F9();
+
+// variadic type equality
+alias int F10(int);
+alias int F11(int...);
+alias int F12(int, ...);
+
+// linkage equality
+alias extern(C) int F13(int);
+alias extern(D) int F14(int);
+alias extern(Windows) int F15(int);
+
+// ref & @property equality
+alias int F16(int);
+alias ref int F17(int);
+alias @property int F18(int);


### PR DESCRIPTION
In Phobos `std.typecons` and `std.traits` use this `alias` syntax:

```
 alias StorageClasses_opt BasicType FuncDeclarator ;
```

```
FuncDeclarator:
    BasicType2opt Identifier FuncDeclaratorSuffix
```

 As AFAICT there's no alternative syntax to this, replacing the few uses sadly doesn't work.
Hence, it would be very appreciated if Dscanner (and thus libdparse) could parse these declarations at least to the degree of not throwing a hard error ;-)
I gave this a shot and it looks like it's very hard to support.

References:
- https://dlang.org/spec/declaration.html#alias
- https://dlang.org/spec/function.html#FuncDeclarator