### PR TITLE
Fix testTokenChecks: add missing __FILE_FULL_PATH__

### DIFF
--- a/test/tester.d
+++ b/test/tester.d
@@ -223,6 +223,7 @@ void testTokenChecks()
         case tok!"__DATE__":
         case tok!"__EOF__":
         case tok!"__FILE__":
+        case tok!"__FILE_FULL_PATH__":
         case tok!"__FUNCTION__":
         case tok!"__gshared":
         case tok!"__LINE__":


### PR DESCRIPTION
This should bump the coverage enormously as the testsuite aborted on an `AssertionError` before it could parse / lex any file in the coverage mode.