### PR TITLE
fix #153 - Missing pragmas in AST

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -272,6 +272,7 @@ public:
     /** */ void visit(const Postblit postblit) { postblit.accept(this); }
     /** */ void visit(const PowExpression powExpression) { powExpression.accept(this); }
     /** */ void visit(const PragmaDeclaration pragmaDeclaration) { pragmaDeclaration.accept(this); }
+    /** */ void visit(const PragmaStatement pragmaStatement) { pragmaStatement.accept(this); }
     /** */ void visit(const PragmaExpression pragmaExpression) { pragmaExpression.accept(this); }
     /** */ void visit(const PrimaryExpression primaryExpression) { primaryExpression.accept(this); }
     /** */ void visit(const Register register) { register.accept(this); }
@@ -2261,9 +2262,9 @@ public:
             switchStatement, finalSwitchStatement, continueStatement,
             breakStatement, returnStatement, gotoStatement, withStatement,
             synchronizedStatement, tryStatement, throwStatement,
-            scopeGuardStatement, asmStatement, conditionalStatement,
-            staticAssertStatement, versionSpecification, debugSpecification,
-            expressionStatement));
+            scopeGuardStatement, asmStatement, pragmaStatement,
+            conditionalStatement, staticAssertStatement, versionSpecification,
+            debugSpecification, expressionStatement));
     }
     /** */ LabeledStatement labeledStatement;
     /** */ BlockStatement blockStatement;
@@ -2284,6 +2285,7 @@ public:
     /** */ ThrowStatement throwStatement;
     /** */ ScopeGuardStatement scopeGuardStatement;
     /** */ AsmStatement asmStatement;
+    /** */ PragmaStatement pragmaStatement;
     /** */ ConditionalStatement conditionalStatement;
     /** */ StaticAssertStatement staticAssertStatement;
     /** */ VersionSpecification versionSpecification;
@@ -2443,6 +2445,20 @@ public:
     }
     /** */ Token identifier;
     /** */ ArgumentList argumentList;
+    mixin OpEquals;
+}
+
+///
+final class PragmaStatement : ASTNode
+{
+public:
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(pragmaExpression, statement, blockStatement));
+    }
+    /** */ PragmaExpression pragmaExpression;
+    /** */ Statement statement;
+    /** */ BlockStatement blockStatement;
     mixin OpEquals;
 }
 

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4393,6 +4393,34 @@ class Parser
     }
 
     /**
+     * Parses a PragmaStatement
+     *
+     * $(GRAMMAR $(RULEDEF pragmaStatement):
+     *        $(RULE pragmaExpression) $(RULE statement)
+     *      | $(RULE pragmaExpression) $(RULE blockStatement)
+     *      | $(RULE pragmaExpression) $(LITERAL ';')
+     */
+    PragmaStatement parsePragmaStatement()
+    {
+        mixin (traceEnterAndExit!(__FUNCTION__));
+        auto node = allocator.make!PragmaStatement;
+        mixin(parseNodeQ!(`node.pragmaExpression`, `PragmaExpression`));
+        if (current == tok!"{")
+        {
+            mixin(parseNodeQ!(`node.blockStatement`, `BlockStatement`));
+        }
+        else if (current == tok!";")
+        {
+            advance();
+        }
+        else
+        {
+            mixin(parseNodeQ!(`node.statement`, `Statement`));
+        }
+        return node;
+    }
+
+    /**
      * Parses a PrimaryExpression
      *
      * $(GRAMMAR $(RULEDEF primaryExpression):
@@ -4795,6 +4823,7 @@ class Parser
      *     | $(RULE tryStatement)
      *     | $(RULE throwStatement)
      *     | $(RULE scopeGuardStatement)
+     *     | $(RULE pragmaStatement)
      *     | $(RULE asmStatement)
      *     | $(RULE conditionalStatement)
      *     | $(RULE staticAssertStatement)
@@ -4861,6 +4890,9 @@ class Parser
             break;
         case tok!"asm":
             mixin(parseNodeQ!(`node.asmStatement`, `AsmStatement`));
+            break;
+        case tok!"pragma":
+            mixin(parseNodeQ!(`node.pragmaStatement`, `PragmaStatement`));
             break;
         case tok!"final":
             if (peekIs(tok!"switch"))

--- a/test/pass_files/pragmas.d
+++ b/test/pass_files/pragmas.d
@@ -1,0 +1,11 @@
+module a;
+
+void foo()
+{
+    pragma(bar) baz = 8;
+
+    pragma(bar)
+    {
+        baz = 8;
+    }
+}


### PR DESCRIPTION
Parses PragmaStatement.

The official grammar is

```
PragmaStatement:
    Pragma NoScopeStatement
```

Here i've rather replaced NoScopeStatement by its content since it doesn't exist in dparse:

```
PragmaStatement:
    Pragma ; // rule 1
    Pragma Statement // rule 2
    Pragma BlockStatement // rule 3
```

which is unless i mistake, the same. The result AST is checked in dscanner.
I didn't know what to do with the old PragmaDeclaration so i left it so that actually only rule 2 & 3 are handled by the new code. Maybe it can be dprecated in another commit.