### PR TITLE
Fix deprecation: 'switch' skips declaration of variable

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4486,15 +4486,17 @@ class Parser
         case tok!"const":
         case tok!"inout":
         case tok!"shared":
-            advance();
-            expect(tok!"(");
-            mixin(parseNodeQ!(`node.type`, `Type`));
-            expect(tok!")");
-            expect(tok!".");
-            const ident = expect(tok!"identifier");
-            if (ident !is null)
-                node.primary = *ident;
-            break;
+            {
+                advance();
+                expect(tok!"(");
+                mixin(parseNodeQ!(`node.type`, `Type`));
+                expect(tok!")");
+                expect(tok!".");
+                const ident = expect(tok!"identifier");
+                if (ident !is null)
+                    node.primary = *ident;
+                break;
+            }
 		foreach (B; BasicTypes) { case B: }
             node.basicType = advance();
             if (currentIs(tok!"."))


### PR DESCRIPTION
Fixes this warning: `Deprecation: 'switch' skips declaration of variable std.d.parser.Parser.parsePrimaryExpression.ident`
I cannot test this well, but we hit this deprecation when compiling an older version of libdparse with LDC 1.3.0. See https://issues.dlang.org/show_bug.cgi?id=16254 and https://github.com/dlang/dmd/pull/5869 .

Thanks.