### PR TITLE
fix issue #162

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4214,6 +4214,12 @@ class Parser
             {
                 advance();
                 mixin(parseNodeQ!(`node.default_`, `AssignExpression`));
+
+                if (currentIs(tok!"..."))
+                {
+                    advance();
+                    node.vararg = true;
+                }
             }
             else if (currentIs(tok!"["))
             {

--- a/test/pass_files/function_declarations.d
+++ b/test/pass_files/function_declarations.d
@@ -47,3 +47,5 @@ void bar()
 void cVarArg(int, ...);
 enum bool isInputRange = is(typeof((inout int = 0){}));
 auto a = b => b * 2;
+
+int typesafeVarArg(int a = 1, int[] rest = [] ...) { return 1; }


### PR DESCRIPTION
parse the following case:
```d
void fun(int i = 1, int[] rest = null ...)
{
}
```