### PR TITLE
test with min required compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ d:
   - dmd-nightly
   - dmd-beta
   - dmd
+  - dmd-2.071.0
   - ldc-beta
   - ldc
 sudo: false


### PR DESCRIPTION
Recently libdparse backwards compatibility with older than 2.071 phobos was broken for a simple nextPow2 usage.
https://github.com/dlang-community/libdparse/pull/148/files
Better be explicit and aware what the oldest supported D version is.