### PR TITLE
fix #156 - Parser bug with assoc-array literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Online documentation is available [here](https://dlang-community.github.io/libdp
 Tests are present in the test directory. To run them execute the run\_tests.sh
 script. Running the tests on Windows is not currently supported.
 
+# Differences with the official grammar
+* [Static array initialization syntax](http://dlang.org/arrays.html#static-init-static). Due to ambiguities they are supported when the expression that gives the elements indexes is not an array. In the opposite case they are parsed as associative array literals.
+
 # Unsupported Syntax
-* [Static array initialization syntax](http://dlang.org/arrays.html#static-init-static). Due to ambiguities they are supported when the expression that gives the elements indexes is not an array. In the opposite case they parsed as associative array literals.
 * [Class allocators](http://dlang.org/class.html#allocators). These are deprecated in D2.
 * [Class deallocators](http://dlang.org/class.html#deallocators). These are deprecated in D2.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Tests are present in the test directory. To run them execute the run\_tests.sh
 script. Running the tests on Windows is not currently supported.
 
 # Unsupported Syntax
-* [Static array initialization syntax](http://dlang.org/arrays.html#static-init-static). This syntax is ambiguous because it looks like an associative array literal.
+* [Static array initialization syntax](http://dlang.org/arrays.html#static-init-static). Due to ambiguities they are supported when the expression that gives the elements indexes is not an array. In the opposite case they parsed as associative array literals.
 * [Class allocators](http://dlang.org/class.html#allocators). These are deprecated in D2.
 * [Class deallocators](http://dlang.org/class.html#deallocators). These are deprecated in D2.

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -3399,6 +3399,7 @@ unittest // issue #165
     EpoTest et = new EpoTest;
     et.visit(m);
     assert(et.visited);
+}
 
 unittest // issue #156
 {

--- a/test/pass_files/issue0156.d
+++ b/test/pass_files/issue0156.d
@@ -1,0 +1,9 @@
+module a;
+
+void foo()
+{
+    const a = ["a":"b"];
+    const a = [1:1];
+    const a = [[1]:"a"];
+    const a = [[1]:[1]];
+}


### PR DESCRIPTION
The issue is fixed by supporting static array initialization in most cases. Why ?

- associative array literals are less frequent since they require constant expressions.
- the index in static array initializers is usually a simple primary (char literal or int literal).

Based on these two facts we can take a descision when there's an ambiguity.
There are still cases of errors because a bit of semantic is actually required to be 100% exact.
In case of errors, the static array init is in an assoc array literal. I believe that these cases could be
handled in DSymbol.