### PR TITLE
attach comment to templatized enum decl

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -1549,6 +1549,7 @@ public:
     /** */ TemplateParameters templateParameters;
     /** */ ExpressionNode assignExpression;
     /** */ Type type;
+    /** */ string comment;
     mixin OpEquals;
 }
 

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -2604,6 +2604,7 @@ class Parser
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!EponymousTemplateDeclaration;
+        node.comment = current.comment;
         advance(); // enum
         const ident = expect(tok!"identifier");
         mixin (nullCheck!`ident`);


### PR DESCRIPTION
before quite recently (#166) EponymousTemplateDecl were not parsed at all.
Required for https://github.com/dlang-community/harbored-mod/issues/88