### PR TITLE
fix #176 - infinite loop on align syntax error inside AsmStatement

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -532,9 +532,20 @@ class Parser
             advance(); // align
             node.hasAlign = true;
             if (currentIsOneOf(tok!"intLiteral", tok!"identifier"))
+            {
                 node.identifierOrIntegerOrOpcode = advance();
+                if (!currentIs(tok!";"))
+                {
+                    error("';' expected.");
+                    advance();
+                    return null;
+                }
+            }
             else
+            {
                 error("Identifier or integer literal expected.");
+                return null;
+            }
         }
         else if (currentIsOneOf(tok!"identifier", tok!"in", tok!"out", tok!"int"))
         {

--- a/test/fail_files/issue0176.d
+++ b/test/fail_files/issue0176.d
@@ -1,0 +1,1 @@
+void foo(){ asm{ align 8); }}


### PR DESCRIPTION
Please once merged also push the `v0.7.2-alpha.2` tag. D-Scanner and DCD need to get the dependency upgraded.