### PR TITLE
More consistent error messages, always use backticks for literals

### DIFF
--- a/src/dparse/lexer.d
+++ b/src/dparse/lexer.d
@@ -1317,7 +1317,7 @@ private pure nothrow @safe:
                     }
                     else
                     {
-                        error("Error: \" expected to end delimited string literal");
+                        error("Error: `\"` expected to end delimited string literal");
                         token = Token(tok!"");
                         return;
                     }
@@ -1365,7 +1365,7 @@ private pure nothrow @safe:
             range.popFront();
         }
         else
-            error(`" expected`);
+            error("`\"` expected");
         IdType type = tok!"stringLiteral";
         lexStringSuffix(type);
         token = Token(type, cache.intern(range.slice(mark)), line, column, index);
@@ -1616,7 +1616,7 @@ private pure nothrow @safe:
         else
         {
     err:
-            error("Error: Expected ' to end character literal");
+            error("Error: Expected `'` to end character literal");
             token = Token(tok!"");
         }
     }

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -536,7 +536,7 @@ class Parser
                 node.identifierOrIntegerOrOpcode = advance();
                 if (!currentIs(tok!";"))
                 {
-                    error("';' expected.");
+                    error("`;` expected.");
                     advance();
                     return null;
                 }
@@ -660,7 +660,7 @@ class Parser
                 mixin(parseNodeQ!(`node.identifierChain`, `IdentifierChain`));
             break;
         default:
-            error("Float literal, integer literal, $, or identifier expected.");
+            error("Float literal, integer literal, `$`, or identifier expected.");
             return null;
         }
         return node;
@@ -713,7 +713,7 @@ class Parser
         {
             if (!functionAttributes.put(parseFunctionAttribute()))
             {
-                error("Function attribute or '{' expected");
+                error("Function attribute or `{` expected");
                 return null;
             }
         }
@@ -780,7 +780,7 @@ class Parser
                 node.right = advance();
             return node;
         default:
-            error("Expected an identifier, 'byte', 'short', 'int', 'float', 'double', or 'real'");
+            error("Expected an identifier, `byte`, `short`, `int`, `float`, `double`, or `real`");
             return null;
         }
     }
@@ -977,7 +977,7 @@ class Parser
         mixin (nullCheck!`start`);
         if (!moreTokens)
         {
-            error(`"(", or identifier expected`);
+            error("`(`, or identifier expected");
             return null;
         }
         node.startLocation = start.index;
@@ -1002,7 +1002,7 @@ class Parser
             expect(tok!")");
             break;
         default:
-            error(`"(", or identifier expected`);
+            error("`(`, or identifier expected");
             return null;
         }
         if (moreTokens) node.endLocation = current().index;
@@ -1239,7 +1239,7 @@ class Parser
             advance();
             break;
         default:
-            error("Identifier or semicolon expected following \"break\"");
+            error("Identifier or semicolon expected following `break`");
             return null;
         }
         return node;
@@ -1420,7 +1420,7 @@ class Parser
             node.first = advance();
             break;
         default:
-            error("const, immutable, inout, or shared expected");
+            error("`const`, `immutable`, `inout`, or `shared` expected");
             return null;
         }
         return node;
@@ -1584,7 +1584,7 @@ class Parser
             mixin(parseNodeQ!(`node.staticIfCondition`, `StaticIfCondition`));
             break;
         default:
-            error(`"version", "debug", or "static" expected`);
+            error("`version`, `debug`, or `static` expected");
             return null;
         }
         return node;
@@ -1772,7 +1772,7 @@ class Parser
             advance();
             break;
         default:
-            error(`Identifier or semicolon expected following "continue"`);
+            error("Identifier or semicolon expected following `continue`");
             return null;
         }
         return node;
@@ -1962,7 +1962,7 @@ class Parser
         case tok!"{":
             if (node.attributes.empty)
             {
-                error("declaration expected instead of '{'");
+                error("declaration expected instead of `{`");
                 return null;
             }
             advance();
@@ -2157,7 +2157,7 @@ class Parser
                 mixin(parseNodeQ!(`node.versionSpecification`, `VersionSpecification`));
             else
             {
-                error(`"=" or "(" expected following "version"`);
+                error("`=` or `(` expected following `version`");
                 return null;
             }
             break;
@@ -2363,7 +2363,7 @@ class Parser
         mixin(tokenCheck!"~");
         if (!moreTokens)
         {
-            error("'this' expected");
+            error("`this` expected");
             return null;
         }
         node.index = current.index;
@@ -2449,7 +2449,7 @@ class Parser
                 }
                 else
                 {
-                    error("',' or '}' expected");
+                    error("`,` or `}` expected");
                     if (currentIs(tok!"}"))
                         break;
                 }
@@ -2812,7 +2812,7 @@ class Parser
             node.type = advance().type;
         else
         {
-            error(`"foreach" or "foreach_reverse" expected`);
+            error("`foreach` or `foreach_reverse` expected");
             return null;
         }
         node.startIndex = current().index;
@@ -2961,7 +2961,7 @@ class Parser
             break;
         default:
             if (validate)
-                error(`@attribute, "pure", or "nothrow" expected`);
+                error("`@`attribute, `pure`, or `nothrow` expected");
             return null;
         }
         return node;
@@ -3007,7 +3007,7 @@ class Parser
         }
         else
         {
-            error("'in', 'out', 'body', or block statement expected");
+            error("`in`, `out`, `body`, or block statement expected");
             return null;
         }
         return node;
@@ -3101,7 +3101,7 @@ class Parser
         mixin(tokenCheck!(`node.name`, "identifier"));
         if (!currentIs(tok!"("))
         {
-            error("'(' expected");
+            error("`(` expected");
             return null;
         }
         const p = peekPastParens();
@@ -3210,7 +3210,7 @@ class Parser
                 mixin(parseNodeQ!(`node.expression`, `Expression`));
             break;
         default:
-            error(`Identifier, "default", or "case" expected`);
+            error("Identifier, `default`, or `case` expected");
             return null;
         }
         mixin(tokenCheck!";");
@@ -3925,7 +3925,7 @@ class Parser
             mixin(parseNodeQ!(`node.mixinExpression`, `MixinExpression`));
         else
         {
-            error(`"(" or identifier expected`);
+            error("`(` or identifier expected");
             return null;
         }
         expect(tok!";");
@@ -5056,7 +5056,7 @@ class Parser
             }
             else
             {
-                error(`"switch" expected`);
+                error("`switch` expected");
                 return null;
             }
         case tok!"debug":
@@ -5080,7 +5080,7 @@ class Parser
                 mixin(parseNodeQ!(`node.staticForeachStatement`, `StaticForeachStatement`));
             else
             {
-                error("'if' or 'assert' or 'foreach' or 'foreach_reverse' expected.");
+                error("`if`, `assert`, `foreach` or `foreach_reverse` expected.");
                 return null;
             }
             break;
@@ -6114,7 +6114,7 @@ class Parser
             goto default;
         default:
             if (validate)
-                error(`"const", "immutable", "inout", or "shared" expected`);
+                error("`const`, `immutable`, `inout`, or `shared` expected");
             return tok!"";
         }
     }
@@ -6257,7 +6257,7 @@ class Parser
             ownArray(node.memberFunctionAttributes, memberFunctionAttributes);
             return node;
         default:
-            error(`"*", "[", "delegate", or "function" expected.`);
+            error("`*`, `[`, `delegate`, or `function` expected.");
             return null;
         }
     }
@@ -6632,7 +6632,7 @@ class Parser
 			node.token = advance();
 		else
 		{
-			error(`Expected an integer literal, an identifier, "assert", or "unittest"`);
+			error("Expected an integer literal, an identifier, `assert`, or `unittest`");
 			return null;
 		}
 		expect(tok!")");
@@ -7380,7 +7380,7 @@ protected:
             auto token = (index < tokens.length
                 ? (tokens[index].text is null ? str(tokens[index].type) : tokens[index].text)
                 : "EOF");
-            error("Expected " ~  tokenString ~ " instead of " ~ token,
+            error("Expected `" ~  tokenString ~ "` instead of `" ~ token ~ "`",
                 !shouldNotAdvance);
             return null;
         }
@@ -7639,7 +7639,7 @@ protected:
                     goto emptyBody;
                 else
                 {
-                    error("Struct body or ';' expected");
+                    error("Struct body or `;` expected");
                     return null;
                 }
             }


### PR DESCRIPTION
Sometimes literals inside message were enclosed between single quotes, sometimes between double quotes. Now are always used backticks.