### PR TITLE
Use -de for libdparse

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,4 +4,5 @@
 	"targetType": "library",
 	"description": "Library for lexing and parsing D source code",
 	"license": "BSL-1.0",
+	"buildRequirements": ["disallowDeprecations"],
 }

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -18,7 +18,7 @@ echo "Running unit tests..."
 echo -e "${GREEN}DONE${NORMAL}"
 
 echo -en "Compiling tester... "
-${DMD} tester.d ../src/std/experimental/*.d ../src/dparse/*.d -g -I../src/ || exit 1
+${DMD} tester.d ../src/std/experimental/*.d ../src/dparse/*.d -g -de -I../src/ || exit 1
 echo -e "${GREEN}DONE${NORMAL}"
 
 for i in $PASS_FILES; do
@@ -56,7 +56,7 @@ fi
 
 find . -name "*.lst" | xargs rm -f
 echo -en "Generating coverage reports... "
-${DMD} tester.d -cov ../src/std/experimental/*.d ../src/dparse/*.d  -I../src/ || exit 1
+${DMD} tester.d -cov ../src/std/experimental/*.d ../src/dparse/*.d  -de -I../src/ || exit 1
 ./tester $PASS_FILES $FAIL_FILES 2>/dev/null 1>/dev/null
 rm -rf coverage/
 mkdir coverage/


### PR DESCRIPTION
This will prevent annoyances like CircleCi (see e,g. [1]) on Phobos getting broken as the Project Tester uses `-de` and thus PRs at dmd can't break libdparse.

[1] https://github.com/dlang-community/libdparse/pull/188