### PR TITLE
fix #193 - Possible infinite loop when the type suffix is for an AA with a type starting with a TypeConstructor

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -3569,7 +3569,7 @@ unittest // issue #193
                     .identifier.text == "Type1");
                 assert(type.typeSuffixes.length == 1);
             }
-            else if (tc == 3) // immutable
+            else if (tc == 3) // immutable(
             {
                 assert(type.type2.typeConstructor == tok!"immutable");
                 assert(type.type2.typeIdentifierPart is null);

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3304,8 +3304,13 @@ class Parser
             advance();
             if (!currentIs(tok!"]"))
             {
+                node.indexer = parseAssignExpression();
+                if (node.indexer is null)
+                {
+                    goToBookmark(b);
+                    return node;
+                }
                 c = allocator.setCheckpoint;
-                mixin(parseNodeQ!(`node.indexer`, `AssignExpression`));
             }
             expect(tok!"]");
             if (!currentIs(tok!"."))

--- a/test/fail_files/issue0158.d
+++ b/test/fail_files/issue0158.d
@@ -1,0 +1,1 @@
+T[++const() null @NotAnAssignExpr / immutable].Y y;


### PR DESCRIPTION
What happened when the bookmark was not restored is hard to reproduce so i test the AST.
Sorry but this will require again tags here, in dsymbol and PRs in D-Scanner, Dsymbol and DCD.