### PR TITLE
Disable nightly + beta builds for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,18 @@
 platform: x64
 environment:
  matrix:
-  - DC: dmd
-    DVersion: nightly
-    arch: x64
-  - DC: dmd
-    DVersion: nightly
-    arch: x86
-  - DC: dmd
-    DVersion: beta
-    arch: x64
-  - DC: dmd
-    DVersion: beta
-    arch: x86
+  #- DC: dmd
+    #DVersion: nightly
+    #arch: x64
+  #- DC: dmd
+    #DVersion: nightly
+    #arch: x86
+  #- DC: dmd
+    #DVersion: beta
+    #arch: x64
+  #- DC: dmd
+    #DVersion: beta
+    #arch: x86
   - DC: dmd
     DVersion: stable
     arch: x64


### PR DESCRIPTION
The less builds we use on AppVeyor, the less can fail!