### PR TITLE
Always update the git submodules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
           - libevent-dev
 script:
   # note: for dlang project tester, which doesn't clone automatically
-  - if [ ! -d stdx-allocator ]; then git submodule update --init --recursive; fi
+  - git submodule update --init --recursive
   #
   - cd test && ./run_tests.sh && cd ..
   - find test/coverage -type f -exec mv {} . \;


### PR DESCRIPTION
Project Tester is still failing with:

```
+ [ ! -d stdx-allocator ]
+ cd test
+ ./run_tests.sh
find: ‘../stdx-allocator/source’: No such file or directory
Compiling unit tests...../src/dparse/parser.d(9): Error: module `mallocator` is in file 'stdx/allocator/mallocator.d' which cannot be read
```

So I assume this is due to the directory being existent, but being empty.

See also: https://github.com/dlang/ci/pull/205