### PR TITLE
Upgrade stdx.allocator to 2.77.2

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,7 +9,7 @@
 		"--min-protection=Protected"
 	],
 	"dependencies": {
-            "stdx-allocator": "~>2.77.0"
+            "stdx-allocator": "~>2.77.2"
 	},
 	"-ddoxTool": "scod"
 }


### PR DESCRIPTION
This is to ensure Circle CI passes at dlang/phobos#6515

cc @BBasile