### PR TITLE
Set all internal helpers non-virtual

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -6881,7 +6881,7 @@ class Parser
         return index < tokens.length;
     }
 
-protected:
+protected: final:
 
     uint suppressedErrorCount;
 


### PR DESCRIPTION
I was inspecting the object file for the parser (because of https://github.com/dlang-community/D-Scanner/issues/593) and realized that all internal helpers (`currentIs()`, `trace()`, etc) are virtual:

![parse_helper_virt](https://user-images.githubusercontent.com/16154339/40889165-6e07bf44-6762-11e8-8dfd-9b90e5d9acc6.png)

And DMD is not able to devirtualize them (the screenshot is made with -O -release -inline).

So this will make parsing faster.