### PR TITLE
Support for DIP1009 (new contracts syntax), close #218

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -1742,14 +1742,14 @@ final class FunctionBody : ASTNode
 public:
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(inStatement, outStatement, bodyStatement,
+        mixin (visitIfNotNull!(inStatements, outStatements, bodyStatement,
             blockStatement));
     }
 
     /** */ BlockStatement blockStatement;
     /** */ BodyStatement bodyStatement;
-    /** */ OutStatement outStatement;
-    /** */ InStatement inStatement;
+    /** */ OutStatement[] outStatements;
+    /** */ InStatement[] inStatements;
     mixin OpEquals;
 }
 

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -1424,9 +1424,9 @@ class Formatter(Sink)
                 format(blockStatement);
                 return;
             }
-            if (inStatement)
+            foreach(inStatement; inStatements)
                 format(inStatement);
-            if (outStatement)
+            foreach(outStatement; outStatements)
                 format(outStatement);
             if (bodyStatement)
                 format(bodyStatement);

--- a/test/fail_files/contracts.d
+++ b/test/fail_files/contracts.d
@@ -1,0 +1,11 @@
+void foo() out(true) do {}
+void foo() out(;true, "false") out {} {}
+void foo() out(;true, "false",,) do {}
+void foo() out(
+void foo() out$
+void foo() out
+void foo() in(
+void foo() in$
+void foo() in
+
+struct Fpp{invariant()}

--- a/test/pass_files/function_declarations.d
+++ b/test/pass_files/function_declarations.d
@@ -49,3 +49,28 @@ enum bool isInputRange = is(typeof((inout int = 0){}));
 auto a = b => b * 2;
 
 int typesafeVarArg(int a = 1, int[] rest = [] ...) { return 1; }
+
+void foo() in(true) do {}
+void foo() in(true,) do {}
+void foo() in(true,"false") do {}
+void foo() in(true,"false",) do {}
+void foo() in(true) in(true) do {}
+void foo() in(true) {}
+void foo() in(true) in(true) {}
+void foo() in(true) in {} do {}
+void foo() in {} in {} do {}
+
+void foo() out(;true) do {}
+void foo() out(;true, "false") do {}
+void foo() out(;true, "false",) do {}
+void foo() out(;true) out(;true) do {}
+void foo() out(;true,) {}
+void foo() out(;true) out(;true) {}
+void foo() out(;true) out {} do {}
+void foo() out {} out {} do {}
+
+void foo() in(true) out(;true) do {}
+void foo() out(; true) in(true) do {}
+void foo() out(result; true) in(true) do {}
+void foo() in(true) out(result; true) in(true) {}
+void foo() in(true) out(result; true) in(true);

--- a/test/pass_files/structs.d
+++ b/test/pass_files/structs.d
@@ -14,6 +14,8 @@ struct S
 	{
 		assert (x == 10);
 	}
+	invariant(true);
+	invariant(true, "false");
 }
 struct S;
 struct S {}


### PR DESCRIPTION
The changes are implemented without huge AST modification. `InContractExpression` and `OutContractExpression` are lowered to `InStatement` and `OuStatement`. For now the grammar in the DDOC comments still needs to be updated and once done it wont be nice, because of the lowering.