### PR TITLE
fix #267 - Infinite loop caused by the `in` keyword

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3085,7 +3085,11 @@ class Parser
                         inStatements.put(s);
                     else return null;
                 }
-                else return null;
+                else
+                {
+                    error("`{` or `(` expected");
+                    return null;
+                }
             }
             else if (currentIs(tok!"out"))
             {
@@ -3120,7 +3124,11 @@ class Parser
                         outStatements.put(s);
                     else return null;
                 }
-                else return null;
+                else
+                {
+                    error("`(` expected");
+                    return null;
+                }
             }
             else break;
         }

--- a/test/fail_files/contracts.d
+++ b/test/fail_files/contracts.d
@@ -7,5 +7,7 @@ void foo() out
 void foo() in(
 void foo() in$
 void foo() in
+void foo() { in }
+void foo() { out }
 
 struct Fpp{invariant()}


### PR DESCRIPTION
Tested to fix the problem in dastworx.