### PR TITLE
fix #147, fix #285, better performance with huge array initializers

### DIFF
--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -494,9 +494,16 @@ class Formatter(Sink)
         debug(verbose) writeln("AutoDeclaration");
 
         /**
+        StorageClasses[] storageClasses;
         Token[] identifiers;
         Initializer[] initializers;
         **/
+
+        foreach(sc; decl.storageClasses)
+        {
+            format(sc);
+            space();
+        }
 
         // zip doesn't work here, dmd 2.064.2
         foreach(i, part; decl.parts)

--- a/test/tester.d
+++ b/test/tester.d
@@ -309,7 +309,7 @@ int main(string[] args)
         config.fileName = arg;
         const(Token)[] tokens = getTokensForParser(fileBytes, config, &cache);
         RollbackAllocator rba;
-        parseModule(ParserConfig(tokens, arg, &rba, &messageFunction));
+        parseModule(ParserConfig(tokens, arg, &rba, &messageFunction, null, null, null, true));
     }
     writefln("Finished parsing with %d errors and %d warnings.",
             errorCount, warningCount);


### PR DESCRIPTION
An new parser property allows to take only one array element per dimension of an `ArrayInitializer`, which has for effect to save the amount of memory used by the AST. This property will be set depending on the product, e.g DSymbol yes (just need one to infer auto arrays), D-Scanner AST printer no (need accurate AST), etc.