### PR TITLE
Add a ParserConfig struct, close #287

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -3258,7 +3258,7 @@ unittest // issue #133
     RollbackAllocator ra;
     LexerConfig cf = LexerConfig("", StringBehavior.source);
     StringCache ca = StringCache(16);
-    Module m = parseModule(getTokensForParser(src, cf, &ca), "", &ra);
+    Module m = ParserConfig(getTokensForParser(src, cf, &ca), "", &ra).parseModule();
     TkTest t = new TkTest;
     t.visit(m);
 }
@@ -3276,7 +3276,7 @@ unittest // issue #165
     RollbackAllocator ra;
     LexerConfig cf = LexerConfig("", StringBehavior.source);
     StringCache ca = StringCache(16);
-    Module m = parseModule(getTokensForParser(src, cf, &ca), "", &ra);
+    Module m = ParserConfig(getTokensForParser(src, cf, &ca), "", &ra).parseModule();
     EpoTest et = new EpoTest;
     et.visit(m);
     assert(et.visited);
@@ -3312,7 +3312,7 @@ unittest // issue #156
     {
         // no colon so array.
         string src1 = q{void main(){const arr = [[0]];}};
-        Module m = parseModule(getTokensForParser(src1, cf, &ca), "", &ra);
+        Module m = parseModule(ParserConfig(getTokensForParser(src1, cf, &ca), "", &ra));
         Test t = new Test;
         t.visit(m);
         assert(t.arrValueOnly);
@@ -3320,7 +3320,7 @@ unittest // issue #156
     {
         // simple primary before colon, assume array.
         string src2 = q{void main(){const arr = [0:0];}};
-        Module m = parseModule(getTokensForParser(src2, cf, &ca), "", &ra);
+        Module m = ParserConfig(getTokensForParser(src2, cf, &ca), "", &ra).parseModule();
         Test t = new Test;
         t.visit(m);
         assert(t.arrIndex);
@@ -3330,7 +3330,7 @@ unittest // issue #156
     {
         // more complex exp before colon, assume AA.
         string src3 = q{void main(){const arr = [[0]:0];}};
-        Module m = parseModule(getTokensForParser(src3, cf, &ca), "", &ra);
+        Module m = ParserConfig(getTokensForParser(src3, cf, &ca), "", &ra).parseModule();
         Test t = new Test;
         t.visit(m);
         assert(!t.arrIndex);
@@ -3363,12 +3363,12 @@ unittest // issue #170
     LexerConfig cf = LexerConfig("", StringBehavior.source);
     StringCache ca = StringCache(16);
 
-    Module m = parseModule(getTokensForParser(Test170_F.src, cf, &ca), "", &ra);
+    Module m = ParserConfig(getTokensForParser(Test170_F.src, cf, &ca), "", &ra).parseModule();
     Test170_F t170_f = new Test170_F;
     t170_f.visit(m);
     assert(t170_f.visited);
 
-    m = parseModule(getTokensForParser(Test170_S.src, cf, &ca), "", &ra);
+    m = ParserConfig(getTokensForParser(Test170_S.src, cf, &ca), "", &ra).parseModule();
     Test170_S t170_s = new Test170_S;
     t170_s.visit(m);
     assert(t170_s.visited);
@@ -3423,7 +3423,7 @@ unittest // issue #193
     LexerConfig cf = LexerConfig("", StringBehavior.source);
     StringCache ca = StringCache(16);
 
-    Module m = parseModule(getTokensForParser(Test193.src, cf, &ca), "", &ra);
+    Module m = ParserConfig(getTokensForParser(Test193.src, cf, &ca), "", &ra).parseModule();
     Test193 t193 = new Test193;
     t193.visit(m);
 }

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -3951,7 +3951,7 @@ void testFormatNode(Node)(string sourceCode)
     StringCache cache = StringCache(32);
     RollbackAllocator rba;
     auto toks = getTokensForParser(code, config, &cache);
-    Module mod = parseModule(toks, "stdin", &rba);
+    Module mod = parseModule(ParserConfig(toks, "stdin", &rba));
     (new CatchInterestingStuff).visit(mod);
 }
 

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -17,50 +17,86 @@ import std.string : format;
 // Caution: generates 180 megabytes of logging for std.datetime
 //version = dparse_verbose;
 
+
+/**
+ * Prototype for a custom parser message function or delegate.
+ * Params:
+ *      fileName = The source file name.
+ *      line = The line in the source, 0 based.
+ *      column = The column in the source, 0 based.
+ *      message = Datailed message.
+ *      isError = Indicates if the message is a warning (`false`) or a if it's an error (`true`).
+ */
+alias MessageFunction = void function(string fileName , size_t line, size_t column, string message, bool isError);
+
+/// ditto
+alias MessageDelegate = void delegate(string, size_t, size_t, string, bool);
+
+/**
+ * Parser configuration struct
+ */
+struct ParserConfig
+{
+    /// The tokens parsed by dparse.lexer.
+    const(Token)[] tokens;
+    /// The name of the file being parsed
+    string fileName;
+    /// A pointer to a rollback allocator.
+    RollbackAllocator* allocator;
+    /// An optional function used to handle warnings and errors.
+    MessageFunction messageFunction;
+    /// An optional delegate used to handle warnings and errors.
+    /// Set either this one or messageFunction, not both.
+    MessageDelegate messageDelegate;
+    /// An optional pointer to a variable receiving the error count.
+    uint* errorCount;
+    /// An optional pointer to a variable receiving the warning count.
+    uint* warningCount;
+}
+
+
 /**
  * Params:
- *     tokens = the tokens parsed by dparse.lexer
- *     fileName = the name of the file being parsed
- *     messageFunction = a function to call on error or warning messages.
- *         The parameters are the file name, line number, column number,
- *         the error or warning message, and a boolean (true means error, false
- *         means warning).
- * Returns: the parsed module
+ *      parserConfig = a parser configuration.
+ * Returns:
+ *      The parsed module
  */
-Module parseModule(const(Token)[] tokens, string fileName, RollbackAllocator* allocator,
-    void delegate(string, size_t, size_t, string, bool) messageFunction = null,
-    uint* errorCount = null, uint* warningCount = null)
+Module parseModule()(auto ref ParserConfig parserConfig)
 {
     auto parser = new Parser();
-    parser.fileName = fileName;
-    parser.tokens = tokens;
-    parser.messageDg = messageFunction;
-    parser.allocator = allocator;
-    auto mod = parser.parseModule();
-    if (warningCount !is null)
-        *warningCount = parser.warningCount;
-    if (errorCount !is null)
-        *errorCount = parser.errorCount;
+    with (parserConfig)
+    {
+        parser.fileName = fileName;
+        parser.tokens = tokens;
+        parser.messageFunction = messageFunction;
+        parser.messageDelegate = messageDelegate;
+        parser.allocator = allocator;
+    }
+    Module mod = parser.parseModule();
+    with (parserConfig)
+    {
+        if (warningCount !is null)
+            *warningCount = parser.warningCount;
+        if (errorCount !is null)
+            *errorCount = parser.errorCount;
+    }
     return mod;
 }
 
-/// Ditto
-deprecated("Use the overload accepting a delegate instead of a function")
+deprecated("Use the parseModule overload that takes a ParserConfig instead")
 Module parseModule(const(Token)[] tokens, string fileName, RollbackAllocator* allocator,
-    void function(string, size_t, size_t, string, bool) messageFunction,
-    uint* errorCount = null, uint* warningCount = null)
+    MessageFunction messageFunction, uint* errorCount = null, uint* warningCount = null)
 {
-    auto parser = new Parser();
-    parser.fileName = fileName;
-    parser.tokens = tokens;
-    parser.messageFunction = messageFunction;
-    parser.allocator = allocator;
-    auto mod = parser.parseModule();
-    if (warningCount !is null)
-        *warningCount = parser.warningCount;
-    if (errorCount !is null)
-        *errorCount = parser.errorCount;
-    return mod;
+    return ParserConfig(tokens, fileName, allocator, messageFunction, null,
+        errorCount, warningCount).parseModule();
+}
+
+deprecated("Use the parseModule overload that takes a ParserConfig instead")
+Module parseModule(const(Token)[] tokens, string fileName, RollbackAllocator* allocator,
+    MessageDelegate messageDelegate, uint* errorCount = null, uint* warningCount = null)
+{
+    return ParserConfig(tokens, fileName, allocator, null, messageDelegate,
+        errorCount, warningCount).parseModule();
 }
 
 /**
@@ -7043,18 +7079,14 @@ class Parser
     RollbackAllocator* allocator;
 
     /**
-     * Function that is called when a warning or error is encountered.
+     * Function or delegate that is called when a warning or error is encountered.
      * The parameters are the file name, line number, column number,
      * and the error or warning message.
      */
-    deprecated("Use 'messageDg' instead")
-    public alias messageFunction = messageFunction_;
+    MessageFunction messageFunction;
 
     /// Ditto
-    public void delegate(string, size_t, size_t, string, bool) messageDg;
-
-    /// Ditto
-    private void function(string, size_t, size_t, string, bool) messageFunction_;
+    MessageDelegate messageDelegate;
 
     void setTokens(const(Token)[] tokens)
     {
@@ -7524,10 +7556,10 @@ protected: final:
         ++warningCount;
         auto column = index < tokens.length ? tokens[index].column : 0;
         auto line = index < tokens.length ? tokens[index].line : 0;
-        if (messageDg !is null)
-            messageDg(fileName, line, column, message, false);
-        else if (messageFunction_ !is null)
-            messageFunction_(fileName, line, column, message, false);
+        if (messageDelegate !is null)
+            messageDelegate(fileName, line, column, message, false);
+        else if (messageFunction !is null)
+            messageFunction(fileName, line, column, message, false);
         else
             stderr.writefln("%s(%d:%d)[warn]: %s", fileName, line, column, message);
     }
@@ -7540,10 +7572,10 @@ protected: final:
             ++errorCount;
             auto column = index < tokens.length ? tokens[index].column : tokens[$ - 1].column;
             auto line = index < tokens.length ? tokens[index].line : tokens[$ - 1].line;
-            if (messageDg !is null)
-                messageDg(fileName, line, column, message, true);
-            else if (messageFunction_ !is null)
-                messageFunction_(fileName, line, column, message, true);
+            if (messageDelegate !is null)
+                messageDelegate(fileName, line, column, message, true);
+            else if (messageFunction !is null)
+                messageFunction(fileName, line, column, message, true);
             else
                 stderr.writefln("%s(%d:%d)[error]: %s", fileName, line, column, message);
         }

--- a/subprojects/stdx-allocator.wrap
+++ b/subprojects/stdx-allocator.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = stdx-allocator
 url       = https://github.com/dlang-community/stdx-allocator.git
-revision  = head
+revision  = v2.77.4

--- a/test/tester.d
+++ b/test/tester.d
@@ -309,7 +309,7 @@ int main(string[] args)
         config.fileName = arg;
         const(Token)[] tokens = getTokensForParser(fileBytes, config, &cache);
         RollbackAllocator rba;
-        parseModule(tokens, arg, &rba, &messageFunction);
+        parseModule(ParserConfig(tokens, arg, &rba, &messageFunction));
     }
     writefln("Finished parsing with %d errors and %d warnings.",
             errorCount, warningCount);


### PR DESCRIPTION
Why such a radical change ?

- the struct allows to pass a config created from a `StructInitializer`, which is the only versatile way that's not based on N overloads. Most of the time the current code is compatible, i.e in existing code just surround parseModule parameters with `ParserConfig()`, **easy maintenance**.
-  both a function and a delegate message function are allowed (no more deprecation), which will allow to remove all the `toDelegate` which were added last year.
- The change allows **nice UFCS style expressions** : `ParserConfig(...).parseModule();`
- Nothing is deprecated because of point 1 and also because this change would be part of 0.10.x, i.e **no breaking changes** if the rule of thumb that's to use the `~>` version operator in DUB json is respected.