### PR TITLE
Fix issue 291: do not require do{} for in{} followed by in()

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3084,6 +3084,7 @@ class Parser
                 }
                 else if (next.type == tok!"(")
                 {
+                    requireDo = false;
                     const size_t inTokenLocation = current.index;
                     advance();
                     advance();
@@ -3113,6 +3114,7 @@ class Parser
                 }
                 else if (next.type == tok!"(")
                 {
+                    requireDo = false;
                     const size_t outTokenLocation = current.index;
                     advance();
                     advance();
@@ -3164,7 +3166,7 @@ class Parser
         }
         else if (requireDo && currentIs(tok!"{"))
         {
-            error("`do` exptected after InStatement or OutStatement");
+            error("`do` expected after InStatement or OutStatement");
             return null;
         }
         else if (!inStatements.length && !outStatements.length)

--- a/test/pass_files/issue0291.d
+++ b/test/pass_files/issue0291.d
@@ -1,0 +1,6 @@
+module issue0291;
+
+void foo()
+in { } // "so you need do{}?"
+out (; true) // No you don't, but libdparse thinks you still do.
+{ }


### PR DESCRIPTION
The only thing that matters is the nature of the last pre/postcondition. If it's a {}, you need do{}; if it's a (), you don't.