### PR TITLE
 Implement DIP1009 correctly (#303)

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -242,6 +242,7 @@ abstract class ASTVisitor
     /** */ void visit(const ImportDeclaration importDeclaration) { importDeclaration.accept(this); }
     /** */ void visit(const ImportExpression importExpression) { importExpression.accept(this); }
     /** */ void visit(const IndexExpression indexExpression) { indexExpression.accept(this); }
+    /** */ void visit(const InContractExpression inContractExpression) { inContractExpression.accept(this); }
     /** */ void visit(const InExpression inExpression) { inExpression.accept(this); }
     /** */ void visit(const InStatement inStatement) { inStatement.accept(this); }
     /** */ void visit(const Initialize initialize) { initialize.accept(this); }
@@ -268,6 +269,7 @@ abstract class ASTVisitor
     /** */ void visit(const Operands operands) { operands.accept(this); }
     /** */ void visit(const OrExpression orExpression) { orExpression.accept(this); }
     /** */ void visit(const OrOrExpression orOrExpression) { orOrExpression.accept(this); }
+    /** */ void visit(const OutContractExpression outContractExpression) { outContractExpression.accept(this); }
     /** */ void visit(const OutStatement outStatement) { outStatement.accept(this); }
     /** */ void visit(const ParameterAttribute parameterAttribute) { parameterAttribute.accept(this); }
     /** */ void visit(const Parameter parameter) { parameter.accept(this); }
@@ -1671,14 +1673,17 @@ final class FunctionBody : ASTNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(inStatements, outStatements, bodyStatement,
+        mixin (visitIfNotNull!(inStatements, inContractExpressions,
+            outStatements, outContractExpressions, bodyStatement,
             blockStatement));
     }
 
     /** */ BlockStatement blockStatement;
     /** */ BodyStatement bodyStatement;
     /** */ OutStatement[] outStatements;
+    /** */ OutContractExpression[] outContractExpressions;
     /** */ InStatement[] inStatements;
+    /** */ InContractExpression[] inContractExpressions;
     mixin OpEquals;
 }
 
@@ -1910,6 +1915,19 @@ final class IndexExpression : ExpressionNode
 }
 
 ///
+final class InContractExpression : ASTNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(assertion, message));
+    }
+    /** */ size_t inTokenLocation;
+    /** */ ExpressionNode assertion;
+    /** */ ExpressionNode message;
+    mixin OpEquals;
+}
+
+///
 final class InExpression : ExpressionNode
 {
     override void accept(ASTVisitor visitor) const
@@ -1977,9 +1995,11 @@ final class Invariant : ASTNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(blockStatement));
+        mixin (visitIfNotNull!(blockStatement, assertion, message));
     }
     /** */ BlockStatement blockStatement;
+    /** */ ExpressionNode assertion;
+    /** */ ExpressionNode message;
     /** */ string comment;
     size_t line;
     size_t index;
@@ -2285,6 +2305,20 @@ final class OrOrExpression : ExpressionNode
         mixin (visitIfNotNull!(left, right));
     }
     mixin BinaryExpressionBody;
+    mixin OpEquals;
+}
+
+///
+final class OutContractExpression : ASTNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(parameter, assertion, message));
+    }
+    /** */ size_t outTokenLocation;
+    /** */ Token parameter;
+    /** */ ExpressionNode assertion;
+    /** */ ExpressionNode message;
     mixin OpEquals;
 }
 

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -180,7 +180,6 @@ abstract class ASTVisitor
     /** */ void visit(const AutoDeclaration autoDeclaration) { autoDeclaration.accept(this); }
     /** */ void visit(const AutoDeclarationPart autoDeclarationPart) { autoDeclarationPart.accept(this); }
     /** */ void visit(const BlockStatement blockStatement) { blockStatement.accept(this); }
-    /** */ void visit(const BodyStatement bodyStatement) { bodyStatement.accept(this); }
     /** */ void visit(const BreakStatement breakStatement) { breakStatement.accept(this); }
     /** */ void visit(const BaseClass baseClass) { baseClass.accept(this); }
     /** */ void visit(const BaseClassList baseClassList) { baseClassList.accept(this); }
@@ -969,17 +968,6 @@ final class BlockStatement : ASTNode
     size_t endLocation;
 
     /** */ DeclarationsAndStatements declarationsAndStatements;
-    mixin OpEquals;
-}
-
-///
-final class BodyStatement : ASTNode
-{
-    override void accept(ASTVisitor visitor) const
-    {
-        mixin (visitIfNotNull!(blockStatement));
-    }
-    /** */ BlockStatement blockStatement;
     mixin OpEquals;
 }
 

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -170,6 +170,7 @@ abstract class ASTVisitor
     /** */ void visit(const AsmTypePrefix asmTypePrefix) { asmTypePrefix.accept(this); }
     /** */ void visit(const AsmUnaExp asmUnaExp) { asmUnaExp.accept(this); }
     /** */ void visit(const AsmXorExp asmXorExp) { asmXorExp.accept(this); }
+    /** */ void visit(const AssertArguments assertArguments) { assertArguments.accept(this); }
     /** */ void visit(const AssertExpression assertExpression) { assertExpression.accept(this); }
     /** */ void visit(const AssignExpression assignExpression) { assignExpression.accept(this); }
     /** */ void visit(const AssocArrayLiteral assocArrayLiteral) { assocArrayLiteral.accept(this); }
@@ -819,16 +820,27 @@ final class AsmXorExp : ExpressionNode
 }
 
 ///
-final class AssertExpression : ExpressionNode
+final class AssertArguments : ASTNode
 {
     override void accept(ASTVisitor visitor) const
     {
         mixin (visitIfNotNull!(assertion, message));
     }
-    /** */ size_t line;
-    /** */ size_t column;
     /** */ ExpressionNode assertion;
     /** */ ExpressionNode message;
+    mixin OpEquals;
+}
+
+///
+final class AssertExpression : ExpressionNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(assertArguments));
+    }
+    /** */ size_t line;
+    /** */ size_t column;
+    /** */ AssertArguments assertArguments;
     mixin OpEquals;
 }
 
@@ -1919,11 +1931,10 @@ final class InContractExpression : ASTNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(assertion, message));
+        mixin (visitIfNotNull!(assertArguments));
     }
     /** */ size_t inTokenLocation;
-    /** */ ExpressionNode assertion;
-    /** */ ExpressionNode message;
+    /** */ AssertArguments assertArguments;
     mixin OpEquals;
 }
 
@@ -1995,11 +2006,10 @@ final class Invariant : ASTNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(blockStatement, assertion, message));
+        mixin (visitIfNotNull!(blockStatement, assertArguments));
     }
     /** */ BlockStatement blockStatement;
-    /** */ ExpressionNode assertion;
-    /** */ ExpressionNode message;
+    /** */ AssertArguments assertArguments;
     /** */ string comment;
     size_t line;
     size_t index;
@@ -2313,12 +2323,11 @@ final class OutContractExpression : ASTNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(parameter, assertion, message));
+        mixin (visitIfNotNull!(parameter, assertArguments));
     }
     /** */ size_t outTokenLocation;
     /** */ Token parameter;
-    /** */ ExpressionNode assertion;
-    /** */ ExpressionNode message;
+    /** */ AssertArguments assertArguments;
     mixin OpEquals;
 }
 

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -229,6 +229,7 @@ abstract class ASTVisitor
     /** */ void visit(const FunctionAttribute functionAttribute) { functionAttribute.accept(this); }
     /** */ void visit(const FunctionBody functionBody) { functionBody.accept(this); }
     /** */ void visit(const FunctionCallExpression functionCallExpression) { functionCallExpression.accept(this); }
+    /** */ void visit(const FunctionContract functionContract) { functionContract.accept(this); }
     /** */ void visit(const FunctionDeclaration functionDeclaration) { functionDeclaration.accept(this); }
     /** */ void visit(const FunctionLiteralExpression functionLiteralExpression) { functionLiteralExpression.accept(this); }
     /** */ void visit(const GotoStatement gotoStatement) { gotoStatement.accept(this); }
@@ -245,6 +246,8 @@ abstract class ASTVisitor
     /** */ void visit(const IndexExpression indexExpression) { indexExpression.accept(this); }
     /** */ void visit(const InContractExpression inContractExpression) { inContractExpression.accept(this); }
     /** */ void visit(const InExpression inExpression) { inExpression.accept(this); }
+    /** */ void visit(const InOutContractExpression inOutContractExpression) { inOutContractExpression.accept(this); }
+    /** */ void visit(const InOutStatement inOutStatement) { inOutStatement.accept(this); }
     /** */ void visit(const InStatement inStatement) { inStatement.accept(this); }
     /** */ void visit(const Initialize initialize) { initialize.accept(this); }
     /** */ void visit(const Initializer initializer) { initializer.accept(this); }
@@ -257,6 +260,7 @@ abstract class ASTVisitor
     /** */ void visit(const LastCatch lastCatch) { lastCatch.accept(this); }
     /** */ void visit(const LinkageAttribute linkageAttribute) { linkageAttribute.accept(this); }
     /** */ void visit(const MemberFunctionAttribute memberFunctionAttribute) { memberFunctionAttribute.accept(this); }
+    /** */ void visit(const MissingFunctionBody missingFunctionBody) { missingFunctionBody.accept(this); }
     /** */ void visit(const MixinDeclaration mixinDeclaration) { mixinDeclaration.accept(this); }
     /** */ void visit(const MixinExpression mixinExpression) { mixinExpression.accept(this); }
     /** */ void visit(const MixinTemplateDeclaration mixinTemplateDeclaration) { mixinTemplateDeclaration.accept(this); }
@@ -290,6 +294,7 @@ abstract class ASTVisitor
     /** */ void visit(const ShiftExpression shiftExpression) { shiftExpression.accept(this); }
     /** */ void visit(const SingleImport singleImport) { singleImport.accept(this); }
     /** */ void visit(const Index index) { index.accept(this); }
+    /** */ void visit(const SpecifiedFunctionBody specifiedFunctionBody) { specifiedFunctionBody.accept(this); }
     /** */ void visit(const Statement statement) { statement.accept(this); }
     /** */ void visit(const StatementNoCaseNoDefault statementNoCaseNoDefault) { statementNoCaseNoDefault.accept(this); }
     /** */ void visit(const StaticAssertDeclaration staticAssertDeclaration) { staticAssertDeclaration.accept(this); }
@@ -1685,17 +1690,11 @@ final class FunctionBody : ASTNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(inStatements, inContractExpressions,
-            outStatements, outContractExpressions, bodyStatement,
-            blockStatement));
+        mixin (visitIfNotNull!(specifiedFunctionBody, missingFunctionBody));
     }
 
-    /** */ BlockStatement blockStatement;
-    /** */ BodyStatement bodyStatement;
-    /** */ OutStatement[] outStatements;
-    /** */ OutContractExpression[] outContractExpressions;
-    /** */ InStatement[] inStatements;
-    /** */ InContractExpression[] inContractExpressions;
+    /** */ SpecifiedFunctionBody specifiedFunctionBody;
+    /** */ MissingFunctionBody missingFunctionBody;
     mixin OpEquals;
 }
 
@@ -1710,6 +1709,18 @@ final class FunctionCallExpression : ExpressionNode
     /** */ UnaryExpression unaryExpression;
     /** */ TemplateArguments templateArguments;
     /** */ Arguments arguments;
+    mixin OpEquals;
+}
+
+///
+final class FunctionContract : ASTNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(inOutContractExpression, inOutStatement));
+    }
+    /** */ InOutContractExpression inOutContractExpression;
+    /** */ InOutStatement inOutStatement;
     mixin OpEquals;
 }
 
@@ -1743,11 +1754,11 @@ final class FunctionLiteralExpression : ExpressionNode
     override void accept(ASTVisitor visitor) const
     {
         mixin (visitIfNotNull!(returnType, parameters, functionAttributes,
-                memberFunctionAttributes, functionBody, assignExpression));
+                memberFunctionAttributes, specifiedFunctionBody, assignExpression));
     }
     /** */ ExpressionNode assignExpression;
     /** */ FunctionAttribute[] functionAttributes;
-    /** */ FunctionBody functionBody;
+    /** */ SpecifiedFunctionBody specifiedFunctionBody;
     /** */ IdType functionOrDelegate;
     /** */ MemberFunctionAttribute[] memberFunctionAttributes;
     /** */ Parameters parameters;
@@ -1951,6 +1962,30 @@ final class InExpression : ExpressionNode
 }
 
 ///
+final class InOutContractExpression : ASTNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(inContractExpression, outContractExpression));
+    }
+    /** */ InContractExpression inContractExpression;
+    /** */ OutContractExpression outContractExpression;
+    mixin OpEquals;
+}
+
+///
+final class InOutStatement : ASTNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(inStatement, outStatement));
+    }
+    /** */ InStatement inStatement;
+    /** */ OutStatement outStatement;
+    mixin OpEquals;
+}
+
+///
 final class InStatement : ASTNode
 {
     override void accept(ASTVisitor visitor) const
@@ -2103,6 +2138,17 @@ final class MemberFunctionAttribute : ASTNode
     }
     /** */ IdType tokenType;
     /** */ AtAttribute atAttribute;
+    mixin OpEquals;
+}
+
+///
+final class MissingFunctionBody : ASTNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(functionContracts));
+    }
+    /** */ FunctionContract[] functionContracts;
     mixin OpEquals;
 }
 
@@ -2582,6 +2628,18 @@ final class SingleImport : ASTNode
     }
     /** */ Token rename;
     /** */ IdentifierChain identifierChain;
+    mixin OpEquals;
+}
+
+///
+final class SpecifiedFunctionBody : ASTNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin (visitIfNotNull!(functionContracts, blockStatement));
+    }
+    /** */ FunctionContract[] functionContracts;
+    /** */ BlockStatement blockStatement;
     mixin OpEquals;
 }
 

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -547,16 +547,6 @@ class Formatter(Sink)
             endBlock();
         }
     }
-
-    void format(const BodyStatement bodyStatement)
-    {
-        debug(verbose) writeln("BodyStatement");
-
-        newline();
-        put("do");
-        format(bodyStatement.blockStatement);
-    }
-
     void format(const BreakStatement breakStatement)
     {
         debug(verbose) writeln("BreakStatement");

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -373,7 +373,7 @@ class Formatter(Sink)
         assert(false);
     }
 
-    void format(const AssertExpression assertExpression)
+    void format(const AssertArguments assertArguments)
     {
         debug(verbose) writeln("AssertExpression");
 
@@ -382,15 +382,29 @@ class Formatter(Sink)
         AssignExpression message;
         **/
 
-        with(assertExpression)
+        with(assertArguments)
         {
-            put("assert (");
             format(assertion);
             if (message)
             {
                 put(", ");
                 format(message);
             }
+        }
+    }
+
+    void format(const AssertExpression assertExpression)
+    {
+        debug(verbose) writeln("AssertExpression");
+
+        /**
+        AssertArguments assertArguments;
+        **/
+
+        with(assertExpression)
+        {
+            put("assert (");
+            format(assertArguments);
             put(")");
         }
     }
@@ -1843,12 +1857,7 @@ class Formatter(Sink)
         debug(verbose) writeln("InContractExpression");
 
         put("in (");
-        format(expression.assertion);
-        if (expression.message !is null)
-        {
-            put(", ");
-            format(expression.message);
-        }
+        format(expression.assertArguments);
         put(")");
     }
 
@@ -1942,12 +1951,7 @@ class Formatter(Sink)
         }
         else
         {
-            format(invariant_.assertion);
-            if (invariant_.message !is null)
-            {
-                put("; ");
-                format(invariant_.message);
-            }
+            format(invariant_.assertArguments);
             put(")");
         }
     }
@@ -2289,12 +2293,7 @@ class Formatter(Sink)
         if (expression.parameter != tok!"")
             format(expression.parameter);
         put("; ");
-        format(expression.assertion);
-        if (expression.message !is null)
-        {
-            put(", ");
-            format(expression.message);
-        }
+        format(expression.assertArguments);
         put(")");
     }
 

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -1449,21 +1449,8 @@ class Formatter(Sink)
 
         with(functionBody)
         {
-            if (blockStatement)
-            {
-                format(blockStatement);
-                return;
-            }
-            foreach(inStatement; inStatements)
-                format(inStatement);
-            foreach(inContractExpression; inContractExpressions)
-                format(inContractExpression);
-            foreach(outStatement; outStatements)
-                format(outStatement);
-            foreach(outContractExpression; outContractExpressions)
-                format(outContractExpression);
-            if (bodyStatement)
-                format(bodyStatement);
+            if (specifiedFunctionBody) format(specifiedFunctionBody);
+            if (missingFunctionBody) format(missingFunctionBody);
         }
     }
 
@@ -1484,6 +1471,22 @@ class Formatter(Sink)
             if (unaryExpression) format(unaryExpression);
             if (templateArguments) format(templateArguments);
             if (arguments) format(arguments);
+        }
+    }
+
+    void format(const FunctionContract functionContract)
+    {
+        debug(verbose) writeln("FunctionContract");
+
+        /**
+        InOutContractExpression inOutContractExpression;
+        InOutStatement inOutStatement;
+        **/
+
+        with(functionContract)
+        {
+            if (inOutContractExpression) format(inOutContractExpression);
+            if (inOutStatement) format(inOutStatement);
         }
     }
 
@@ -1536,7 +1539,7 @@ class Formatter(Sink)
         /**
         ExpressionNode assignExpression;
         FunctionAttribute[] functionAttributes;
-        FunctionBody functionBody;
+        SpecifiedFunctionBody specifiedFunctionBody;
         IdType functionOrDelegate;
         MemberFunctionAttribute[] memberFunctionAttributes;
         Parameters parameters;
@@ -1561,8 +1564,8 @@ class Formatter(Sink)
             }
 
             ignoreNewlines = true;
-            if (functionBody)
-                format(functionBody);
+            if (specifiedFunctionBody)
+                format(specifiedFunctionBody);
             else
             {
                 format(identifier);
@@ -1873,6 +1876,29 @@ class Formatter(Sink)
         }
     }
 
+    void format(const InOutContractExpression inOutContractExpression)
+    {
+        debug(verbose) writeln("InOutContractExpression");
+
+        with(inOutContractExpression)
+        {
+            if (inContractExpression) format(inContractExpression);
+            if (outContractExpression) format(outContractExpression);
+            newline();
+        }
+    }
+
+    void format(const InOutStatement inOutStatement)
+    {
+        debug(verbose) writeln("InOutStatement");
+
+        with(inOutStatement)
+        {
+            if (inStatement) format(inStatement);
+            if (outStatement) format(outStatement);
+        }
+    }
+
     void format(const InStatement inStatement)
     {
         debug(verbose) writeln("InStatement");
@@ -2091,6 +2117,18 @@ class Formatter(Sink)
         {
             if (tokenType) put(tokenRep(tokenType));
             else format(atAttribute);
+        }
+    }
+
+    void format(const MissingFunctionBody missingFunctionBody)
+    {
+        debug(verbose) writeln("MissingFunctionBody");
+
+        with(missingFunctionBody)
+        {
+            foreach (contract; functionContracts)
+                format(contract);
+            put(";");
         }
     }
 
@@ -2610,6 +2648,19 @@ class Formatter(Sink)
             put(" = ");
         }
         format(singleImport.identifierChain);
+    }
+
+    void format(const SpecifiedFunctionBody specifiedFunctionBody)
+    {
+        debug(verbose) writeln("SpecifiedFunctionBody");
+
+        with(specifiedFunctionBody)
+        {
+            foreach (contract; functionContracts)
+                format(contract);
+            put("do");
+            format(blockStatement);
+        }
     }
 
     void format(const Statement statement)

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -1442,8 +1442,12 @@ class Formatter(Sink)
             }
             foreach(inStatement; inStatements)
                 format(inStatement);
+            foreach(inContractExpression; inContractExpressions)
+                format(inContractExpression);
             foreach(outStatement; outStatements)
                 format(outStatement);
+            foreach(outContractExpression; outContractExpressions)
+                format(outContractExpression);
             if (bodyStatement)
                 format(bodyStatement);
         }
@@ -1834,6 +1838,20 @@ class Formatter(Sink)
         }
     }
 
+    void format(const InContractExpression expression)
+    {
+        debug(verbose) writeln("InContractExpression");
+
+        put("in (");
+        format(expression.assertion);
+        if (expression.message !is null)
+        {
+            put(", ");
+            format(expression.message);
+        }
+        put(")");
+    }
+
     void format(const InExpression inExpression)
     {
         debug(verbose) writeln("InExpression");
@@ -1916,8 +1934,22 @@ class Formatter(Sink)
 
         putComment(invariant_.comment);
         putAttrs(attrs);
-        put("invariant()");
-        format(invariant_.blockStatement);
+        put("invariant(");
+        if (invariant_.blockStatement !is null)
+        {
+            put(")");
+            format(invariant_.blockStatement);
+        }
+        else
+        {
+            format(invariant_.assertion);
+            if (invariant_.message !is null)
+            {
+                put("; ");
+                format(invariant_.message);
+            }
+            put(")");
+        }
     }
 
     void format(const IsExpression isExpression)
@@ -2247,6 +2279,23 @@ class Formatter(Sink)
     {
         debug(verbose) writeln("OrOrExpression");
         mixin(binary("orOrExpression", "||"));
+    }
+
+    void format(const OutContractExpression expression)
+    {
+        debug(verbose) writeln("OutContractExpression");
+
+        put("out (");
+        if (expression.parameter != tok!"")
+            format(expression.parameter);
+        put("; ");
+        format(expression.assertion);
+        if (expression.message !is null)
+        {
+            put(", ");
+            format(expression.message);
+        }
+        put(")");
     }
 
     void format(const OutStatement stmnt)

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4175,7 +4175,7 @@ class Parser
             if (expect(tok!";") is null)
                 return null;
         }
-        else if (currentIs(tok!"do") || current.text == "body")
+        else if (moreTokens() && (currentIs(tok!"do") || current.text == "body"))
             return null;
         return node;
     }

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3856,6 +3856,7 @@ class Parser
      */
     InContractExpression parseInContractExpression()
     {
+        mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!InContractExpression;
         const i = expect(tok!"in");
         mixin(nullCheck!`i`);
@@ -3875,6 +3876,7 @@ class Parser
      */
     ExpressionNode parseInExpression(ExpressionNode shift = null)
     {
+        mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!InExpression;
         mixin(nullCheck!`node.left = shift is null ? parseShiftExpression() : shift`);
         if (currentIs(tok!"!"))
@@ -3896,6 +3898,7 @@ class Parser
      */
     InStatement parseInStatement()
     {
+        mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!InStatement;
         const i = expect(tok!"in");
         mixin(nullCheck!`i`);
@@ -3914,6 +3917,7 @@ class Parser
      */
     Initializer parseInitializer()
     {
+        mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!Initializer;
         if (currentIs(tok!"void") && peekIsOneOf(tok!",", tok!";"))
             advance();
@@ -3949,6 +3953,7 @@ class Parser
      */
     Invariant parseInvariant()
     {
+        mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!Invariant;
         node.index = current.index;
         node.line = current.line;
@@ -4558,6 +4563,7 @@ class Parser
      */
     OutContractExpression parseOutContractExpression()
     {
+        mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!OutContractExpression;
         const o = expect(tok!"out");
         mixin(nullCheck!`o`);
@@ -4580,6 +4586,7 @@ class Parser
      */
     OutStatement parseOutStatement()
     {
+        mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!OutStatement;
         const o = expect(tok!"out");
         mixin(nullCheck!`o`);

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -5253,8 +5253,8 @@ class Parser
         }
         ownArray(node.functionContracts, contracts);
 
-        if (current.type == tok!"do"
-                || (current.type == tok!"identifier" && current.text == "body"))
+        if (currentIs(tok!"do")
+                || (currentIs(tok!"identifier") && current.text == "body"))
         {
             requireDo = false;
             advance();

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -1247,24 +1247,6 @@ class Parser
     }
 
     /**
-     * Parses a BodyStatement
-     *
-     * $(GRAMMAR $(RULEDEF bodyStatement):
-     *     ($(LITERAL 'body') | $(LITERAL 'do')) $(RULE blockStatement)
-     *     ;)
-     */
-    BodyStatement parseBodyStatement()
-    {
-        mixin(traceEnterAndExit!(__FUNCTION__));
-        auto node = allocator.make!BodyStatement;
-        if (!currentIs(tok!"do") && current.text != "body")
-            return null;
-        advance();
-        mixin(simpleParseItem!("blockStatement|parseBlockStatement"));
-        return node;
-    }
-
-    /**
      * Parses a BreakStatement
      *
      * $(GRAMMAR $(RULEDEF breakStatement):

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -896,10 +896,31 @@ class Parser
     }
 
     /**
+     * Parses an AssertArguments
+     *
+     * $(GRAMMAR $(RULEDEF assertArguments):
+     *     $(RULE assignExpression) ($(LITERAL ',') $(RULE assignExpression))? $(LITERAL ',')?
+     *     ;)
+     */
+    AssertArguments parseAssertArguments()
+    {
+        auto node = allocator.make!AssertArguments;
+        mixin(parseNodeQ!(`node.assertion`, `AssignExpression`));
+        if (currentIs(tok!","))
+            advance();
+        if (currentIs(tok!")"))
+            return node;
+        mixin(parseNodeQ!(`node.message`, `AssignExpression`));
+        if (currentIs(tok!","))
+            advance();
+        return node;
+    }
+
+    /**
      * Parses an AssertExpression
      *
      * $(GRAMMAR $(RULEDEF assertExpression):
-     *     $(LITERAL 'assert') $(LITERAL '$(LPAREN)') $(RULE assignExpression) ($(LITERAL ',') $(RULE assignExpression))? $(LITERAL ',')? $(LITERAL '$(RPAREN)')
+     *     $(LITERAL 'assert') $(LITERAL '$(LPAREN)') $(RULE assertArguments) $(LITERAL '$(RPAREN)')
      *     ;)
      */
     AssertExpression parseAssertExpression()
@@ -910,19 +931,7 @@ class Parser
         node.column = current.column;
         advance(); // "assert"
         mixin(tokenCheck!"(");
-        mixin(parseNodeQ!(`node.assertion`, `AssignExpression`));
-        if (currentIs(tok!","))
-        {
-            advance();
-            if (currentIs(tok!")"))
-            {
-                advance();
-                return node;
-            }
-            mixin(parseNodeQ!(`node.message`, `AssignExpression`));
-        }
-        if (currentIs(tok!","))
-            advance();
+        mixin(parseNodeQ!(`node.assertArguments`, `AssertArguments`));
         mixin(tokenCheck!")");
         return node;
     }
@@ -3842,7 +3851,7 @@ class Parser
      * Parses an InContractExpression
      *
      * $(GRAMMAR $(RULEDEF inContractExpression):
-     *     $(LITERAL 'in') $(LITERAL '$(LPAREN)') $(RULE assignExpression) ($(LITERAL ',') $(RULE assignExpression))? $(LITERAL ',')? $(LITERAL '$(RPAREN)')
+     *     $(LITERAL 'in') $(LITERAL '$(LPAREN)') $(RULE assertArguments) $(LITERAL '$(RPAREN)')
      *     ;)
      */
     InContractExpression parseInContractExpression()
@@ -3852,19 +3861,7 @@ class Parser
         mixin(nullCheck!`i`);
         node.inTokenLocation = i.index;
         mixin(tokenCheck!"(");
-        mixin(parseNodeQ!(`node.assertion`, `AssignExpression`));
-        if (currentIs(tok!","))
-        {
-            advance();
-            if (currentIs(tok!")"))
-            {
-                advance();
-                return node;
-            }
-            mixin(parseNodeQ!(`node.message`, `AssignExpression`));
-        }
-        if (currentIs(tok!","))
-            advance();
+        mixin(parseNodeQ!(`node.assertArguments`, `AssertArguments`));
         mixin(tokenCheck!")");
         return node;
     }
@@ -3946,8 +3943,8 @@ class Parser
      * Parses an Invariant
      *
      * $(GRAMMAR $(RULEDEF invariant):
-     *       $(LITERAL 'invariant') $(RULE blockStatement)
-     *     | $(LITERAL 'invariant') $(LITERAL '$(LPAREN)') $(RULE assignExpression) ($(LITERAL ',') $(RULE assignExpression))? $(LITERAL ',')? $(LITERAL '$(RPAREN)') $(LITERAL ';')
+     *       $(LITERAL 'invariant') ($(LITERAL '$(LPAREN)') $(LITERAL '$(LPAREN)'))? $(RULE blockStatement)
+     *     | $(LITERAL 'invariant') $(LITERAL '$(LPAREN)') $(RULE assertArguments) $(LITERAL '$(RPAREN)') $(LITERAL ';')
      *     ;)
      */
     Invariant parseInvariant()
@@ -3975,19 +3972,7 @@ class Parser
         else if (!mustHaveBlock && currentIs(tok!"("))
         {
             advance();
-            mixin(parseNodeQ!(`node.assertion`, `AssignExpression`));
-            if (currentIs(tok!","))
-            {
-                advance();
-                if (currentIs(tok!")"))
-                {
-                    advance();
-                    return node;
-                }
-                mixin(parseNodeQ!(`node.message`, `AssignExpression`));
-            }
-            if (currentIs(tok!","))
-                advance();
+            mixin(parseNodeQ!(`node.assertArguments`, `AssertArguments`));
             mixin(tokenCheck!")");
         }
         else return null;
@@ -4568,7 +4553,7 @@ class Parser
      * Parses an OutContractExpression
      *
      * $(GRAMMAR $(RULEDEF outContractExpression):
-     *     $(LITERAL 'out') $(LITERAL '$(LPAREN)') $(LITERAL Identifier)? $(LITERAL ';') $(RULE assignExpression) ($(LITERAL ',') $(RULE assignExpression))? $(LITERAL ',')? $(LITERAL '$(RPAREN)')
+     *     $(LITERAL 'out') $(LITERAL '$(LPAREN)') $(LITERAL Identifier)? $(LITERAL ';') $(RULE assertArguments) $(LITERAL '$(RPAREN)')
      *     ;)
      */
     OutContractExpression parseOutContractExpression()
@@ -4581,19 +4566,7 @@ class Parser
         if (currentIs(tok!"identifier"))
             node.parameter = advance();
         mixin(tokenCheck!";");
-        mixin(parseNodeQ!(`node.assertion`, `AssignExpression`));
-        if (currentIs(tok!","))
-        {
-            advance();
-            if (currentIs(tok!")"))
-            {
-                advance();
-                return node;
-            }
-            mixin(parseNodeQ!(`node.message`, `AssignExpression`));
-        }
-        if (currentIs(tok!","))
-            advance();
+        mixin(parseNodeQ!(`node.assertArguments`, `AssertArguments`));
         mixin(tokenCheck!")");
         return node;
     }


### PR DESCRIPTION
This PR adds the following changes from the API perspective:
- new `InContractExpression` and `OutContractExpression` classes to represent expression-based contracts
- new `inContractExpressions` and `outContractExpressions` properties for `FunctionBody` to store them
- new `assertion` and `message` properties for `Invariant` in the case of an expression-based  invariant

These are obviously breaking changes since they change the way `FunctionBody` and `Invariant` store expression-based contracts.