### PR TITLE
fix, dip 1009, semicolon as for "no body" is part of MissinFunctionBody rule

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3254,10 +3254,7 @@ class Parser
         if (isTemplate && currentIs(tok!"if"))
             mixin(parseNodeQ!(`node.constraint`, `Constraint`));
 
-        if (currentIs(tok!";"))
-            advance();
-        else
-            mixin(parseNodeQ!(`node.functionBody`, `FunctionBody`));
+        mixin(parseNodeQ!(`node.functionBody`, `FunctionBody`));
         ownArray(node.memberFunctionAttributes, memberFunctionAttributes);
         return node;
     }


### PR DESCRIPTION
Should have seen this during #304 review, yet another tag required...