### PR TITLE
fix #316 - Regression, function literal parsed as struct initializer

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -3441,9 +3441,33 @@ unittest // issue #170
         override void visit(const FunctionLiteralExpression){visited = true;}
     }
 
+    final class Test170_F1 : ASTVisitor
+    {
+        static string src = q{  const a = {int i;};  };
+        bool visited;
+        alias visit = ASTVisitor.visit;
+        override void visit(const FunctionLiteralExpression){visited = true;}
+    }
+
+    final class Test170_F2 : ASTVisitor
+    {
+        static string src = q{  const a = {};  };
+        bool visited;
+        alias visit = ASTVisitor.visit;
+        override void visit(const FunctionLiteralExpression){visited = true;}
+    }
+
     final class Test170_S : ASTVisitor
     {
         static string src = q{A a = {member : call()};};
+        bool visited;
+        alias visit = ASTVisitor.visit;
+        override void visit(const StructInitializer){visited = true;}
+    }
+
+    final class Test170_S1 : ASTVisitor
+    {
+        static string src = q{  A a = {0};  };
         bool visited;
         alias visit = ASTVisitor.visit;
         override void visit(const StructInitializer){visited = true;}
@@ -3458,10 +3482,25 @@ unittest // issue #170
     t170_f.visit(m);
     assert(t170_f.visited);
 
+    m = ParserConfig(getTokensForParser(Test170_F1.src, cf, &ca), "", &ra).parseModule();
+    Test170_F1 t170_f1 = new Test170_F1;
+    t170_f1.visit(m);
+    assert(t170_f1.visited);
+
+    m = ParserConfig(getTokensForParser(Test170_F2.src, cf, &ca), "", &ra).parseModule();
+    Test170_F2 t170_f2 = new Test170_F2;
+    t170_f2.visit(m);
+    assert(t170_f2.visited);
+
     m = ParserConfig(getTokensForParser(Test170_S.src, cf, &ca), "", &ra).parseModule();
     Test170_S t170_s = new Test170_S;
     t170_s.visit(m);
     assert(t170_s.visited);
+
+    m = ParserConfig(getTokensForParser(Test170_S1.src, cf, &ca), "", &ra).parseModule();
+    Test170_S1 t170_s1 = new Test170_S1;
+    t170_s1.visit(m);
+    assert(t170_s1.visited);
 }
 
 unittest // issue #193

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -3429,78 +3429,51 @@ unittest // issue #156
     }
 }
 
-unittest // issue #170
+unittest // issue #170, issue #316
 {
     import dparse.lexer, dparse.parser, dparse.rollback_allocator;
 
-    final class Test170_F : ASTVisitor
+    abstract class TestCase : ASTVisitor
     {
-        static string src = q{void function() a = {call();};};
+        string src;
         bool visited;
+        this()
+        {
+            RollbackAllocator ra;
+            LexerConfig cf = LexerConfig("", StringBehavior.source);
+            StringCache ca = StringCache(16);
+            Module m = ParserConfig(getTokensForParser(src, cf, &ca), "", &ra).parseModule();
+            visit(m);
+            assert(visited);
+        }
+    }
+
+    class FunctionLiteralExpressionTestCase : TestCase
+    {
         alias visit = ASTVisitor.visit;
         override void visit(const FunctionLiteralExpression){visited = true;}
     }
 
-    final class Test170_F1 : ASTVisitor
+    class StructInitializerTestCase : TestCase
     {
-        static string src = q{  const a = {int i;};  };
-        bool visited;
-        alias visit = ASTVisitor.visit;
-        override void visit(const FunctionLiteralExpression){visited = true;}
-    }
-
-    final class Test170_F2 : ASTVisitor
-    {
-        static string src = q{  const a = {};  };
-        bool visited;
-        alias visit = ASTVisitor.visit;
-        override void visit(const FunctionLiteralExpression){visited = true;}
-    }
-
-    final class Test170_S : ASTVisitor
-    {
-        static string src = q{A a = {member : call()};};
-        bool visited;
         alias visit = ASTVisitor.visit;
         override void visit(const StructInitializer){visited = true;}
     }
 
-    final class Test170_S1 : ASTVisitor
-    {
-        static string src = q{  A a = {0};  };
-        bool visited;
-        alias visit = ASTVisitor.visit;
-        override void visit(const StructInitializer){visited = true;}
-    }
+    new class FunctionLiteralExpressionTestCase
+    {this(){  TestCase.src = q{ void function() a = {call();};}; super(); }};
 
-    RollbackAllocator ra;
-    LexerConfig cf = LexerConfig("", StringBehavior.source);
-    StringCache ca = StringCache(16);
+    new class FunctionLiteralExpressionTestCase
+    {this(){  TestCase.src = q{ const a = {int i;};}; super(); }};
 
-    Module m = ParserConfig(getTokensForParser(Test170_F.src, cf, &ca), "", &ra).parseModule();
-    Test170_F t170_f = new Test170_F;
-    t170_f.visit(m);
-    assert(t170_f.visited);
+    new class FunctionLiteralExpressionTestCase
+    {this(){  TestCase.src = q{ const a = {};}; super(); }};
 
-    m = ParserConfig(getTokensForParser(Test170_F1.src, cf, &ca), "", &ra).parseModule();
-    Test170_F1 t170_f1 = new Test170_F1;
-    t170_f1.visit(m);
-    assert(t170_f1.visited);
+    new class StructInitializerTestCase
+    {this(){  TestCase.src = q{A a = {member : call()};}; super(); }};
 
-    m = ParserConfig(getTokensForParser(Test170_F2.src, cf, &ca), "", &ra).parseModule();
-    Test170_F2 t170_f2 = new Test170_F2;
-    t170_f2.visit(m);
-    assert(t170_f2.visited);
-
-    m = ParserConfig(getTokensForParser(Test170_S.src, cf, &ca), "", &ra).parseModule();
-    Test170_S t170_s = new Test170_S;
-    t170_s.visit(m);
-    assert(t170_s.visited);
-
-    m = ParserConfig(getTokensForParser(Test170_S1.src, cf, &ca), "", &ra).parseModule();
-    Test170_S1 t170_s1 = new Test170_S1;
-    t170_s1.visit(m);
-    assert(t170_s1.visited);
+    new class StructInitializerTestCase
+    {this(){  TestCase.src = q{A a = {0};}; super(); }};
 }
 
 unittest // issue #193

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4492,11 +4492,6 @@ class Parser
             }
             else mixin(parseNodeQ!(`node.assignExpression`, `AssignExpression`));
         }
-        /*else
-            mixin(parseNodeQ!(`node.assignExpression`, `AssignExpression`));
-        if (node.assignExpression is null && node.arrayInitializer is null
-                && node.structInitializer is null)
-            return null;*/
         return node;
     }
 


### PR DESCRIPTION
There must be a problem because the fix is so much simpler than the previous mess.