### PR TITLE
Fix trailing semicolon of invariant seen as an empty statement

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3983,6 +3983,7 @@ class Parser
             advance();
             mixin(parseNodeQ!(`node.assertArguments`, `AssertArguments`));
             mixin(tokenCheck!")");
+            mixin(tokenCheck!";");
         }
         else return null;
         return node;


### PR DESCRIPTION
As the title says, in [expression-based invariants](https://dlang.org/spec/grammar.html#ClassInvariant), a trailing semicolon is needed, but apparently it was forgotten