### PR TITLE
Make all ast nodes contain the parsed tokens

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -418,7 +418,14 @@ template generateOpEquals(T)
         ~ "\treturn true;\n}\nreturn false;";
 }
 
-abstract class ExpressionNode : ASTNode
+abstract class BaseNode : ASTNode
+{
+    /** List of tokens consumed by this AST node */ const(Token)[] tokens;
+
+    abstract void accept(ASTVisitor visitor) const;
+}
+
+abstract class ExpressionNode : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -447,7 +454,7 @@ final class AddExpression : ExpressionNode
 }
 
 ///
-final class AliasDeclaration : ASTNode
+final class AliasDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -465,7 +472,7 @@ final class AliasDeclaration : ASTNode
 }
 
 ///
-final class AliasInitializer : ASTNode
+final class AliasInitializer : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -481,7 +488,7 @@ final class AliasInitializer : ASTNode
 }
 
 ///
-final class AliasThisDeclaration : ASTNode
+final class AliasThisDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -493,7 +500,7 @@ final class AliasThisDeclaration : ASTNode
 }
 
 ///
-final class AlignAttribute : ASTNode
+final class AlignAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -526,7 +533,7 @@ final class AndExpression : ExpressionNode
 }
 
 ///
-final class AnonymousEnumDeclaration : ASTNode
+final class AnonymousEnumDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -538,7 +545,7 @@ final class AnonymousEnumDeclaration : ASTNode
 }
 
 ///
-final class AnonymousEnumMember : ASTNode
+final class AnonymousEnumMember : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -551,7 +558,7 @@ final class AnonymousEnumMember : ASTNode
 }
 
 ///
-final class ArgumentList : ASTNode
+final class ArgumentList : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -564,7 +571,7 @@ final class ArgumentList : ASTNode
 }
 
 ///
-final class Arguments : ASTNode
+final class Arguments : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -575,7 +582,7 @@ final class Arguments : ASTNode
 }
 
 ///
-final class ArrayInitializer : ASTNode
+final class ArrayInitializer : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -588,7 +595,7 @@ final class ArrayInitializer : ASTNode
 }
 
 ///
-final class ArrayLiteral : ASTNode
+final class ArrayLiteral : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -599,7 +606,7 @@ final class ArrayLiteral : ASTNode
 }
 
 ///
-final class ArrayMemberInitialization : ASTNode
+final class ArrayMemberInitialization : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -674,7 +681,7 @@ final class AsmExp : ExpressionNode
 }
 
 ///
-final class AsmInstruction : ASTNode
+final class AsmInstruction : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -735,7 +742,7 @@ final class AsmOrExp : ExpressionNode
 }
 
 ///
-final class AsmPrimaryExp : ASTNode
+final class AsmPrimaryExp : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -775,7 +782,7 @@ final class AsmShiftExp : ExpressionNode
 }
 
 ///
-final class AsmStatement : ASTNode
+final class AsmStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -787,7 +794,7 @@ final class AsmStatement : ASTNode
 }
 
 ///
-final class AsmTypePrefix : ASTNode
+final class AsmTypePrefix : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -799,7 +806,7 @@ final class AsmTypePrefix : ASTNode
 }
 
 ///
-final class AsmUnaExp : ASTNode
+final class AsmUnaExp : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -825,7 +832,7 @@ final class AsmXorExp : ExpressionNode
 }
 
 ///
-final class AssertArguments : ASTNode
+final class AssertArguments : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -865,7 +872,7 @@ final class AssignExpression : ExpressionNode
 }
 
 ///
-final class AssocArrayLiteral : ASTNode
+final class AssocArrayLiteral : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -876,7 +883,7 @@ final class AssocArrayLiteral : ASTNode
 }
 
 ///
-final class AtAttribute : ASTNode
+final class AtAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -891,7 +898,7 @@ final class AtAttribute : ASTNode
 }
 
 ///
-final class Attribute : ASTNode
+final class Attribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -909,7 +916,7 @@ final class Attribute : ASTNode
 }
 
 ///
-final class AttributeDeclaration : ASTNode
+final class AttributeDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -921,7 +928,7 @@ final class AttributeDeclaration : ASTNode
 }
 
 ///
-final class AutoDeclaration : ASTNode
+final class AutoDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -936,7 +943,7 @@ final class AutoDeclaration : ASTNode
     mixin OpEquals;
 }
 
-final class AutoDeclarationPart : ASTNode
+final class AutoDeclarationPart : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -951,7 +958,7 @@ final class AutoDeclarationPart : ASTNode
 }
 
 ///
-final class BlockStatement : ASTNode
+final class BlockStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -973,7 +980,7 @@ final class BlockStatement : ASTNode
 }
 
 ///
-final class BreakStatement : ASTNode
+final class BreakStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -984,7 +991,7 @@ final class BreakStatement : ASTNode
 }
 
 ///
-final class BaseClass : ASTNode
+final class BaseClass : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -995,7 +1002,7 @@ final class BaseClass : ASTNode
 }
 
 ///
-final class BaseClassList : ASTNode
+final class BaseClassList : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1006,7 +1013,7 @@ final class BaseClassList : ASTNode
 }
 
 ///
-final class CaseRangeStatement : ASTNode
+final class CaseRangeStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1020,7 +1027,7 @@ final class CaseRangeStatement : ASTNode
 }
 
 ///
-final class CaseStatement: ASTNode
+final class CaseStatement: BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1033,7 +1040,7 @@ final class CaseStatement: ASTNode
 }
 
 ///
-final class CastExpression: ASTNode
+final class CastExpression: BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1046,7 +1053,7 @@ final class CastExpression: ASTNode
 }
 
 ///
-final class CastQualifier: ASTNode
+final class CastQualifier: BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1058,7 +1065,7 @@ final class CastQualifier: ASTNode
 }
 
 ///
-final class Catches: ASTNode
+final class Catches: BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1070,7 +1077,7 @@ final class Catches: ASTNode
 }
 
 ///
-final class Catch: ASTNode
+final class Catch: BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1083,7 +1090,7 @@ final class Catch: ASTNode
 }
 
 ///
-final class ClassDeclaration: ASTNode
+final class ClassDeclaration: BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1117,7 +1124,7 @@ final class CmpExpression : ExpressionNode
 }
 
 ///
-final class CompileCondition : ASTNode
+final class CompileCondition : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1130,7 +1137,7 @@ final class CompileCondition : ASTNode
 }
 
 ///
-final class ConditionalDeclaration : ASTNode
+final class ConditionalDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1144,7 +1151,7 @@ final class ConditionalDeclaration : ASTNode
 }
 
 ///
-final class ConditionalStatement : ASTNode
+final class ConditionalStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1157,7 +1164,7 @@ final class ConditionalStatement : ASTNode
 }
 
 ///
-final class Constraint : ASTNode
+final class Constraint : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1169,7 +1176,7 @@ final class Constraint : ASTNode
 }
 
 ///
-final class Constructor : ASTNode
+final class Constructor : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1189,7 +1196,7 @@ final class Constructor : ASTNode
 }
 
 ///
-final class ContinueStatement : ASTNode
+final class ContinueStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1200,7 +1207,7 @@ final class ContinueStatement : ASTNode
 }
 
 ///
-final class DebugCondition : ASTNode
+final class DebugCondition : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1212,7 +1219,7 @@ final class DebugCondition : ASTNode
 }
 
 ///
-final class DebugSpecification : ASTNode
+final class DebugSpecification : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1223,7 +1230,7 @@ final class DebugSpecification : ASTNode
 }
 
 ///
-final class Declaration : ASTNode
+final class Declaration : BaseNode
 {
 
     override void accept(ASTVisitor visitor) const
@@ -1316,7 +1323,7 @@ final class Declaration : ASTNode
 }
 
 ///
-final class DeclarationsAndStatements : ASTNode
+final class DeclarationsAndStatements : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1328,7 +1335,7 @@ final class DeclarationsAndStatements : ASTNode
 }
 
 ///
-final class DeclarationOrStatement : ASTNode
+final class DeclarationOrStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1343,7 +1350,7 @@ final class DeclarationOrStatement : ASTNode
 }
 
 ///
-final class Declarator : ASTNode
+final class Declarator : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1358,7 +1365,7 @@ final class Declarator : ASTNode
 }
 
 ///
-final class DeclaratorIdentifierList : ASTNode
+final class DeclaratorIdentifierList : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1369,7 +1376,7 @@ final class DeclaratorIdentifierList : ASTNode
 }
 
 ///
-final class DefaultStatement : ASTNode
+final class DefaultStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1394,7 +1401,7 @@ final class DeleteExpression : ExpressionNode
 }
 
 ///
-final class DeleteStatement : ASTNode
+final class DeleteStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1405,7 +1412,7 @@ final class DeleteStatement : ASTNode
 }
 
 ///
-final class Deprecated : ASTNode
+final class Deprecated : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1416,7 +1423,7 @@ final class Deprecated : ASTNode
 }
 
 ///
-final class Destructor : ASTNode
+final class Destructor : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1432,7 +1439,7 @@ final class Destructor : ASTNode
 }
 
 ///
-final class DoStatement : ASTNode
+final class DoStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1444,7 +1451,7 @@ final class DoStatement : ASTNode
 }
 
 ///
-final class EnumBody : ASTNode
+final class EnumBody : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1465,7 +1472,7 @@ final class EnumBody : ASTNode
 }
 
 ///
-final class EnumDeclaration : ASTNode
+final class EnumDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1478,7 +1485,7 @@ final class EnumDeclaration : ASTNode
     mixin OpEquals;
 }
 
-final class EnumMemberAttribute : ASTNode
+final class EnumMemberAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1490,7 +1497,7 @@ final class EnumMemberAttribute : ASTNode
 }
 
 ///
-final class EnumMember : ASTNode
+final class EnumMember : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1505,7 +1512,7 @@ final class EnumMember : ASTNode
 }
 
 ///
-final class EponymousTemplateDeclaration : ASTNode
+final class EponymousTemplateDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1545,7 +1552,7 @@ final class Expression : ExpressionNode
 }
 
 ///
-final class ExpressionStatement : ASTNode
+final class ExpressionStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1556,7 +1563,7 @@ final class ExpressionStatement : ASTNode
 }
 
 ///
-final class FinalSwitchStatement : ASTNode
+final class FinalSwitchStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1567,7 +1574,7 @@ final class FinalSwitchStatement : ASTNode
 }
 
 ///
-final class Finally : ASTNode
+final class Finally : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1578,7 +1585,7 @@ final class Finally : ASTNode
 }
 
 ///
-final class ForStatement : ASTNode
+final class ForStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1595,7 +1602,7 @@ final class ForStatement : ASTNode
 
 
 ///
-final class Foreach(bool declOnly) : ASTNode
+final class Foreach(bool declOnly) : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1625,7 +1632,7 @@ alias StaticForeachDeclaration = Foreach!true;
 alias ForeachStatement = Foreach!false;
 
 ///
-final class StaticForeachStatement : ASTNode
+final class StaticForeachStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1636,7 +1643,7 @@ final class StaticForeachStatement : ASTNode
 }
 
 ///
-final class ForeachType : ASTNode
+final class ForeachType : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1652,7 +1659,7 @@ final class ForeachType : ASTNode
 }
 
 ///
-final class ForeachTypeList : ASTNode
+final class ForeachTypeList : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1663,7 +1670,7 @@ final class ForeachTypeList : ASTNode
 }
 
 ///
-final class FunctionAttribute : ASTNode
+final class FunctionAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1675,7 +1682,7 @@ final class FunctionAttribute : ASTNode
 }
 
 ///
-final class FunctionBody : ASTNode
+final class FunctionBody : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1703,7 +1710,7 @@ final class FunctionCallExpression : ExpressionNode
 }
 
 ///
-final class FunctionContract : ASTNode
+final class FunctionContract : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1715,7 +1722,7 @@ final class FunctionContract : ASTNode
 }
 
 ///
-final class FunctionDeclaration : ASTNode
+final class FunctionDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1760,7 +1767,7 @@ final class FunctionLiteralExpression : ExpressionNode
 }
 
 ///
-final class GotoStatement : ASTNode
+final class GotoStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1772,7 +1779,7 @@ final class GotoStatement : ASTNode
 }
 
 ///
-final class IdentifierChain : ASTNode
+final class IdentifierChain : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1783,7 +1790,7 @@ final class IdentifierChain : ASTNode
 }
 
 ///
-final class TypeIdentifierPart : ASTNode
+final class TypeIdentifierPart : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1798,7 +1805,7 @@ final class TypeIdentifierPart : ASTNode
 }
 
 ///
-final class IdentifierOrTemplateChain : ASTNode
+final class IdentifierOrTemplateChain : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1810,7 +1817,7 @@ final class IdentifierOrTemplateChain : ASTNode
 }
 
 ///
-final class IdentifierOrTemplateInstance : ASTNode
+final class IdentifierOrTemplateInstance : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1835,7 +1842,7 @@ final class IdentityExpression : ExpressionNode
 }
 
 ///
-final class IfStatement : ASTNode
+final class IfStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1855,7 +1862,7 @@ final class IfStatement : ASTNode
 }
 
 ///
-final class ImportBind : ASTNode
+final class ImportBind : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1867,7 +1874,7 @@ final class ImportBind : ASTNode
 }
 
 ///
-final class ImportBindings : ASTNode
+final class ImportBindings : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1879,7 +1886,7 @@ final class ImportBindings : ASTNode
 }
 
 ///
-final class ImportDeclaration : ASTNode
+final class ImportDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1904,7 +1911,7 @@ final class ImportExpression : ExpressionNode
 }
 
 ///
-final class Index : ASTNode
+final class Index : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1928,7 +1935,7 @@ final class IndexExpression : ExpressionNode
 }
 
 ///
-final class InContractExpression : ASTNode
+final class InContractExpression : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1952,7 +1959,7 @@ final class InExpression : ExpressionNode
 }
 
 ///
-final class InOutContractExpression : ASTNode
+final class InOutContractExpression : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1964,7 +1971,7 @@ final class InOutContractExpression : ASTNode
 }
 
 ///
-final class InOutStatement : ASTNode
+final class InOutStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1976,7 +1983,7 @@ final class InOutStatement : ASTNode
 }
 
 ///
-final class InStatement : ASTNode
+final class InStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1988,7 +1995,7 @@ final class InStatement : ASTNode
 }
 
 ///
-final class Initialize : ASTNode
+final class Initialize : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -1999,7 +2006,7 @@ final class Initialize : ASTNode
 }
 
 ///
-final class Initializer : ASTNode
+final class Initializer : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2010,7 +2017,7 @@ final class Initializer : ASTNode
 }
 
 ///
-final class InterfaceDeclaration : ASTNode
+final class InterfaceDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2027,7 +2034,7 @@ final class InterfaceDeclaration : ASTNode
 }
 
 ///
-final class Invariant : ASTNode
+final class Invariant : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2058,7 +2065,7 @@ final class IsExpression : ExpressionNode
 }
 
 ///
-final class KeyValuePair : ASTNode
+final class KeyValuePair : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2070,7 +2077,7 @@ final class KeyValuePair : ASTNode
 }
 
 ///
-final class KeyValuePairs : ASTNode
+final class KeyValuePairs : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2081,7 +2088,7 @@ final class KeyValuePairs : ASTNode
 }
 
 ///
-final class LabeledStatement : ASTNode
+final class LabeledStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2093,7 +2100,7 @@ final class LabeledStatement : ASTNode
 }
 
 ///
-final class LastCatch : ASTNode
+final class LastCatch : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2106,7 +2113,7 @@ final class LastCatch : ASTNode
 }
 
 ///
-final class LinkageAttribute : ASTNode
+final class LinkageAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2120,7 +2127,7 @@ final class LinkageAttribute : ASTNode
 }
 
 ///
-final class MemberFunctionAttribute : ASTNode
+final class MemberFunctionAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2132,7 +2139,7 @@ final class MemberFunctionAttribute : ASTNode
 }
 
 ///
-final class MissingFunctionBody : ASTNode
+final class MissingFunctionBody : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2143,7 +2150,7 @@ final class MissingFunctionBody : ASTNode
 }
 
 ///
-final class MixinDeclaration : ASTNode
+final class MixinDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2166,7 +2173,7 @@ final class MixinExpression : ExpressionNode
 }
 
 ///
-final class MixinTemplateDeclaration : ASTNode
+final class MixinTemplateDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2177,7 +2184,7 @@ final class MixinTemplateDeclaration : ASTNode
 }
 
 ///
-final class MixinTemplateName : ASTNode
+final class MixinTemplateName : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2190,7 +2197,7 @@ final class MixinTemplateName : ASTNode
 }
 
 ///
-final class Module : ASTNode
+final class Module : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2203,7 +2210,7 @@ final class Module : ASTNode
 }
 
 ///
-final class ModuleDeclaration : ASTNode
+final class ModuleDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2262,7 +2269,7 @@ final class NewExpression : ExpressionNode
 
 
 ///
-final class StatementNoCaseNoDefault : ASTNode
+final class StatementNoCaseNoDefault : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2307,7 +2314,7 @@ final class StatementNoCaseNoDefault : ASTNode
 }
 
 ///
-final class NonVoidInitializer : ASTNode
+final class NonVoidInitializer : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2322,7 +2329,7 @@ final class NonVoidInitializer : ASTNode
 }
 
 ///
-final class Operands : ASTNode
+final class Operands : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2355,7 +2362,7 @@ final class OrOrExpression : ExpressionNode
 }
 
 ///
-final class OutContractExpression : ASTNode
+final class OutContractExpression : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2368,7 +2375,7 @@ final class OutContractExpression : ASTNode
 }
 
 ///
-final class OutStatement : ASTNode
+final class OutStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2380,7 +2387,7 @@ final class OutStatement : ASTNode
     mixin OpEquals;
 }
 
-final class ParameterAttribute : ASTNode
+final class ParameterAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2391,7 +2398,7 @@ final class ParameterAttribute : ASTNode
 }
 
 ///
-final class Parameter : ASTNode
+final class Parameter : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2409,7 +2416,7 @@ final class Parameter : ASTNode
 }
 
 ///
-final class Parameters : ASTNode
+final class Parameters : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2422,7 +2429,7 @@ final class Parameters : ASTNode
 }
 
 ///
-final class Postblit : ASTNode
+final class Postblit : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2448,7 +2455,7 @@ final class PowExpression : ExpressionNode
 }
 
 ///
-final class PragmaDeclaration : ASTNode
+final class PragmaDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2471,7 +2478,7 @@ final class PragmaExpression : ExpressionNode
 }
 
 ///
-final class PragmaStatement : ASTNode
+final class PragmaStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2516,7 +2523,7 @@ final class PrimaryExpression : ExpressionNode
 }
 
 ///
-final class Register : ASTNode
+final class Register : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2541,7 +2548,7 @@ final class RelExpression : ExpressionNode
 }
 
 ///
-final class ReturnStatement : ASTNode
+final class ReturnStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2554,7 +2561,7 @@ final class ReturnStatement : ASTNode
 }
 
 ///
-final class ScopeGuardStatement : ASTNode
+final class ScopeGuardStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2566,7 +2573,7 @@ final class ScopeGuardStatement : ASTNode
 }
 
 ///
-final class SharedStaticConstructor : ASTNode
+final class SharedStaticConstructor : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2582,7 +2589,7 @@ final class SharedStaticConstructor : ASTNode
 }
 
 ///
-final class SharedStaticDestructor : ASTNode
+final class SharedStaticDestructor : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2610,7 +2617,7 @@ final class ShiftExpression : ExpressionNode
 }
 
 ///
-final class SingleImport : ASTNode
+final class SingleImport : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2622,7 +2629,7 @@ final class SingleImport : ASTNode
 }
 
 ///
-final class SpecifiedFunctionBody : ASTNode
+final class SpecifiedFunctionBody : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2634,7 +2641,7 @@ final class SpecifiedFunctionBody : ASTNode
 }
 
 ///
-final class Statement : ASTNode
+final class Statement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2649,7 +2656,7 @@ final class Statement : ASTNode
 }
 
 ///
-final class StaticAssertDeclaration : ASTNode
+final class StaticAssertDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2660,7 +2667,7 @@ final class StaticAssertDeclaration : ASTNode
 }
 
 ///
-final class StaticAssertStatement : ASTNode
+final class StaticAssertStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2671,7 +2678,7 @@ final class StaticAssertStatement : ASTNode
 }
 
 ///
-final class StaticConstructor : ASTNode
+final class StaticConstructor : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2687,7 +2694,7 @@ final class StaticConstructor : ASTNode
 }
 
 ///
-final class StaticDestructor : ASTNode
+final class StaticDestructor : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2703,7 +2710,7 @@ final class StaticDestructor : ASTNode
 }
 
 ///
-final class StaticIfCondition : ASTNode
+final class StaticIfCondition : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2714,7 +2721,7 @@ final class StaticIfCondition : ASTNode
 }
 
 ///
-final class StorageClass : ASTNode
+final class StorageClass : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2730,7 +2737,7 @@ final class StorageClass : ASTNode
 }
 
 ///
-final class StructBody : ASTNode
+final class StructBody : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2751,7 +2758,7 @@ final class StructBody : ASTNode
 }
 
 ///
-final class StructDeclaration : ASTNode
+final class StructDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2766,7 +2773,7 @@ final class StructDeclaration : ASTNode
 }
 
 ///
-final class StructInitializer : ASTNode
+final class StructInitializer : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2779,7 +2786,7 @@ final class StructInitializer : ASTNode
 }
 
 ///
-final class StructMemberInitializer : ASTNode
+final class StructMemberInitializer : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2791,7 +2798,7 @@ final class StructMemberInitializer : ASTNode
 }
 
 ///
-final class StructMemberInitializers : ASTNode
+final class StructMemberInitializers : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2802,7 +2809,7 @@ final class StructMemberInitializers : ASTNode
 }
 
 ///
-final class SwitchStatement : ASTNode
+final class SwitchStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2814,7 +2821,7 @@ final class SwitchStatement : ASTNode
 }
 
 ///
-final class Symbol : ASTNode
+final class Symbol : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2827,7 +2834,7 @@ final class Symbol : ASTNode
 }
 
 ///
-final class SynchronizedStatement : ASTNode
+final class SynchronizedStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2839,7 +2846,7 @@ final class SynchronizedStatement : ASTNode
 }
 
 ///
-final class TemplateAliasParameter : ASTNode
+final class TemplateAliasParameter : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2856,7 +2863,7 @@ final class TemplateAliasParameter : ASTNode
 }
 
 ///
-final class TemplateArgument : ASTNode
+final class TemplateArgument : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2868,7 +2875,7 @@ final class TemplateArgument : ASTNode
 }
 
 ///
-final class TemplateArgumentList : ASTNode
+final class TemplateArgumentList : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2879,7 +2886,7 @@ final class TemplateArgumentList : ASTNode
 }
 
 ///
-final class TemplateArguments : ASTNode
+final class TemplateArguments : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2891,7 +2898,7 @@ final class TemplateArguments : ASTNode
 }
 
 ///
-final class TemplateDeclaration : ASTNode
+final class TemplateDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2916,7 +2923,7 @@ final class TemplateDeclaration : ASTNode
 }
 
 ///
-final class TemplateInstance : ASTNode
+final class TemplateInstance : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2941,7 +2948,7 @@ final class TemplateMixinExpression : ExpressionNode
 }
 
 ///
-final class TemplateParameter : ASTNode
+final class TemplateParameter : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2958,7 +2965,7 @@ final class TemplateParameter : ASTNode
 }
 
 ///
-final class TemplateParameterList : ASTNode
+final class TemplateParameterList : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2969,7 +2976,7 @@ final class TemplateParameterList : ASTNode
 }
 
 ///
-final class TemplateParameters : ASTNode
+final class TemplateParameters : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2980,7 +2987,7 @@ final class TemplateParameters : ASTNode
 }
 
 ///
-final class TemplateSingleArgument : ASTNode
+final class TemplateSingleArgument : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -2991,7 +2998,7 @@ final class TemplateSingleArgument : ASTNode
 }
 
 ///
-final class TemplateThisParameter : ASTNode
+final class TemplateThisParameter : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3002,7 +3009,7 @@ final class TemplateThisParameter : ASTNode
 }
 
 ///
-final class TemplateTupleParameter : ASTNode
+final class TemplateTupleParameter : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3013,7 +3020,7 @@ final class TemplateTupleParameter : ASTNode
 }
 
 ///
-final class TemplateTypeParameter : ASTNode
+final class TemplateTypeParameter : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3026,7 +3033,7 @@ final class TemplateTypeParameter : ASTNode
 }
 
 ///
-final class TemplateValueParameter : ASTNode
+final class TemplateValueParameter : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3041,7 +3048,7 @@ final class TemplateValueParameter : ASTNode
 }
 
 ///
-final class TemplateValueParameterDefault : ASTNode
+final class TemplateValueParameterDefault : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3068,7 +3075,7 @@ final class TernaryExpression : ExpressionNode
 }
 
 ///
-final class ThrowStatement : ASTNode
+final class ThrowStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3091,7 +3098,7 @@ final class TraitsExpression : ExpressionNode
 }
 
 ///
-final class TryStatement : ASTNode
+final class TryStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3104,7 +3111,7 @@ final class TryStatement : ASTNode
 }
 
 ///
-final class Type : ASTNode
+final class Type : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3118,7 +3125,7 @@ final class Type : ASTNode
 }
 
 ///
-final class Type2 : ASTNode
+final class Type2 : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3138,7 +3145,7 @@ final class Type2 : ASTNode
 }
 
 ///
-final class TypeSpecialization : ASTNode
+final class TypeSpecialization : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3150,7 +3157,7 @@ final class TypeSpecialization : ASTNode
 }
 
 ///
-final class TypeSuffix : ASTNode
+final class TypeSuffix : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3222,7 +3229,7 @@ final class UnaryExpression : ExpressionNode
 }
 
 ///
-final class UnionDeclaration : ASTNode
+final class UnionDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3238,7 +3245,7 @@ final class UnionDeclaration : ASTNode
 }
 
 ///
-final class Unittest : ASTNode
+final class Unittest : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3253,7 +3260,7 @@ final class Unittest : ASTNode
 }
 
 ///
-final class VariableDeclaration : ASTNode
+final class VariableDeclaration : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3268,7 +3275,7 @@ final class VariableDeclaration : ASTNode
 }
 
 ///
-final class Vector : ASTNode
+final class Vector : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3279,7 +3286,7 @@ final class Vector : ASTNode
 }
 
 ///
-final class VersionCondition : ASTNode
+final class VersionCondition : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3291,7 +3298,7 @@ final class VersionCondition : ASTNode
 }
 
 ///
-final class VersionSpecification : ASTNode
+final class VersionSpecification : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3302,7 +3309,7 @@ final class VersionSpecification : ASTNode
 }
 
 ///
-final class WhileStatement : ASTNode
+final class WhileStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
@@ -3316,7 +3323,7 @@ final class WhileStatement : ASTNode
 }
 
 ///
-final class WithStatement : ASTNode
+final class WithStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -398,9 +398,8 @@ template generateOpEquals(T)
         {
             enum opEqualsPart = opEqualsPart!(p[0 .. $/2]) ~ opEqualsPart!(p[$/2 .. $]);
         }
-        else static if (p.length && !p[0].among("comment", "line", "column", "endLocation",
-                "startLocation", "endIndex", "startIndex", "index", "dotLocation", "parenOpenLocation")
-            && !isSomeFunction!(typeof(__traits(getMember, T, p[0]))))
+        else static if (p.length && !isSomeFunction!(typeof(__traits(getMember, T, p[0])))
+            && !p[0].among("comment", "line", "column", "endLocation", "startLocation", "index", "dotLocation"))
         {
             static if (isDynamicArray!(typeof(__traits(getMember, T, p[0]))))
             {
@@ -567,9 +566,8 @@ final class ArgumentList : BaseNode
     }
     mixin OpEquals;
     /** */ ExpressionNode[] items;
-
-    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
 }
 
 ///
@@ -591,10 +589,9 @@ final class ArrayInitializer : BaseNode
         mixin (visitIfNotNull!(arrayMemberInitializations));
     }
     mixin OpEquals;
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
     /** */ ArrayMemberInitialization[] arrayMemberInitializations;
-
-    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
 }
 
 ///
@@ -895,9 +892,8 @@ final class AtAttribute : BaseNode
     /** */ ArgumentList argumentList;
     /** */ TemplateInstance templateInstance;
     /** */ Token identifier;
-    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
     mixin OpEquals;
 }
 
@@ -972,12 +968,12 @@ final class BlockStatement : BaseNode
     /**
      * Byte position of the opening brace
      */
-    size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    size_t startLocation;
 
     /**
      * Byte position of the closing brace
      */
-    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.max; }
+    size_t endLocation;
 
     /** */ DeclarationsAndStatements declarationsAndStatements;
     mixin OpEquals;
@@ -1348,9 +1344,8 @@ final class DeclarationOrStatement : BaseNode
 
     /** */ Declaration declaration;
     /** */ Statement statement;
-    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
     mixin OpEquals;
 }
 
@@ -1467,13 +1462,12 @@ final class EnumBody : BaseNode
     /**
      * Byte position of the opening brace
      */
-    size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    size_t startLocation;
 
     /**
      * Byte position of the closing brace
      */
-    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
+    size_t endLocation;
     mixin OpEquals;
 }
 
@@ -1602,13 +1596,7 @@ final class ForStatement : BaseNode
     /** */ Expression test;
     /** */ Expression increment;
     /** */ DeclarationOrStatement declarationOrStatement;
-    /** */ size_t parenOpenLocation() @property
-    {
-        return tokens.length > 1 ? tokens[1].index : size_t.init;
-    }
-
-    deprecated("use parenOpenLocation or tokens instead") alias startIndex = parenOpenLocation;
-
+    /** */ size_t startIndex;
     mixin OpEquals;
 }
 
@@ -1629,19 +1617,11 @@ final class Foreach(bool declOnly) : BaseNode
     /** */ ForeachType foreachType;
     /** */ Expression low;
     /** */ Expression high;
+    /** */ size_t startIndex;
     static if (declOnly)
         /** */ Declaration[] declarations;
     else
         /** */ DeclarationOrStatement declarationOrStatement;
-
-    /** */ size_t parenOpenLocation() @property
-    {
-        enum startLocation = declOnly ? 2 : 1;
-        return tokens.length > startLocation ? tokens[startLocation].index : size_t.init;
-    }
-
-    deprecated("use parenOpenLocation or tokens instead") alias startIndex = parenOpenLocation;
-
     mixin OpEquals;
 }
 
@@ -1875,23 +1855,9 @@ final class IfStatement : BaseNode
     /** */ Expression expression;
     /** */ DeclarationOrStatement thenStatement;
     /** */ DeclarationOrStatement elseStatement;
-    /** */ size_t parenOpenLocation() @property
-    {
-        return tokens.length > 1 ? tokens[1].index : size_t.init;
-    }
-
-    /** */ size_t line() @property
-    {
-        return tokens.length > 0 ? tokens[0].line : size_t.init;
-    }
-
-    /** */ size_t column() @property
-    {
-        return tokens.length > 0 ? tokens[0].column : size_t.init;
-    }
-
-    deprecated("use parenOpenLocation or tokens instead") alias startIndex = parenOpenLocation;
-
+    /** */ size_t startIndex;
+    /** */ size_t line;
+    /** */ size_t column;
     mixin OpEquals;
 }
 
@@ -1928,19 +1894,8 @@ final class ImportDeclaration : BaseNode
     }
     /** */ SingleImport[] singleImports;
     /** */ ImportBindings importBindings;
-    /** */ size_t startIndex() @property
-    {
-        return tokens.length > 0 ? tokens[0].index : size_t.init;
-    }
-
-    /** */ size_t endIndex() @property
-    {
-        if (tokens.length == 0)
-            return size_t.init;
-        else // ";" token
-            return tokens[$ - 1].index + 1;
-    }
-
+    /** */ size_t startIndex;
+    /** */ size_t endIndex;
     mixin OpEquals;
 }
 
@@ -2088,9 +2043,8 @@ final class Invariant : BaseNode
     /** */ BlockStatement blockStatement;
     /** */ AssertArguments assertArguments;
     /** */ string comment;
-    /** */ size_t line() const @property { return tokens.length > 1 ? tokens[0].line : size_t.init; }
-    /** */ size_t index() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-
+    size_t line;
+    size_t index;
     mixin OpEquals;
 }
 
@@ -2264,18 +2218,9 @@ final class ModuleDeclaration : BaseNode
     }
     /** */ Deprecated deprecated_;
     /** */ IdentifierChain moduleName;
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
     /** */ string comment;
-    size_t startLocation() const @property
-    {
-        auto module_ = tokens.countUntil!(a => a.type == tok!"module");
-        if (module_ == -1)
-            return size_t.init;
-        else
-            return tokens[module_].index;
-    }
-
-    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
     mixin OpEquals;
 }
 
@@ -2363,9 +2308,8 @@ final class StatementNoCaseNoDefault : BaseNode
     /** */ VersionSpecification versionSpecification;
     /** */ DebugSpecification debugSpecification;
     /** */ ExpressionStatement expressionStatement;
-    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
     mixin OpEquals;
 }
 
@@ -2611,9 +2555,8 @@ final class ReturnStatement : BaseNode
         mixin (visitIfNotNull!(expression));
     }
     /** */ Expression expression;
-    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
     mixin OpEquals;
 }
 
@@ -2804,13 +2747,12 @@ final class StructBody : BaseNode
     /**
      * Byte position of the opening brace
      */
-    size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    size_t startLocation;
 
     /**
      * Byte position of the closing brace
      */
-    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
+    size_t endLocation;
     /** */ Declaration[] declarations;
     mixin OpEquals;
 }
@@ -2838,9 +2780,8 @@ final class StructInitializer : BaseNode
         mixin (visitIfNotNull!(structMemberInitializers));
     }
     /** */ StructMemberInitializers structMemberInitializers;
-    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
     mixin OpEquals;
 }
 
@@ -2977,8 +2918,7 @@ final class TemplateDeclaration : BaseNode
     /**
      * Byte position of the closing brace
      */
-    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
-
+    size_t endLocation;
     mixin OpEquals;
 }
 
@@ -3352,8 +3292,7 @@ final class VersionCondition : BaseNode
     {
         mixin (visitIfNotNull!(token));
     }
-    /** */ size_t versionIndex() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
-
+    /** */ size_t versionIndex;
     /** */ Token token;
     mixin OpEquals;
 }
@@ -3379,13 +3318,7 @@ final class WhileStatement : BaseNode
 
     /** */ Expression expression;
     /** */ DeclarationOrStatement declarationOrStatement;
-    /** */ size_t parenOpenLocation() @property
-    {
-        return tokens.length > 1 ? tokens[1].index : size_t.init;
-    }
-
-    deprecated("use parenOpenLocation or tokens instead") alias startIndex = parenOpenLocation;
-
+    /** */ size_t startIndex;
     mixin OpEquals;
 }
 

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -398,8 +398,9 @@ template generateOpEquals(T)
         {
             enum opEqualsPart = opEqualsPart!(p[0 .. $/2]) ~ opEqualsPart!(p[$/2 .. $]);
         }
-        else static if (p.length && !isSomeFunction!(typeof(__traits(getMember, T, p[0])))
-            && !p[0].among("comment", "line", "column", "endLocation", "startLocation", "index", "dotLocation"))
+        else static if (p.length && !p[0].among("comment", "line", "column", "endLocation",
+                "startLocation", "endIndex", "startIndex", "index", "dotLocation", "parenOpenLocation")
+            && !isSomeFunction!(typeof(__traits(getMember, T, p[0]))))
         {
             static if (isDynamicArray!(typeof(__traits(getMember, T, p[0]))))
             {
@@ -566,8 +567,9 @@ final class ArgumentList : BaseNode
     }
     mixin OpEquals;
     /** */ ExpressionNode[] items;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
+
+    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
 }
 
 ///
@@ -589,9 +591,10 @@ final class ArrayInitializer : BaseNode
         mixin (visitIfNotNull!(arrayMemberInitializations));
     }
     mixin OpEquals;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
     /** */ ArrayMemberInitialization[] arrayMemberInitializations;
+
+    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
 }
 
 ///
@@ -892,8 +895,9 @@ final class AtAttribute : BaseNode
     /** */ ArgumentList argumentList;
     /** */ TemplateInstance templateInstance;
     /** */ Token identifier;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
+    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -968,12 +972,12 @@ final class BlockStatement : BaseNode
     /**
      * Byte position of the opening brace
      */
-    size_t startLocation;
+    size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
 
     /**
      * Byte position of the closing brace
      */
-    size_t endLocation;
+    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.max; }
 
     /** */ DeclarationsAndStatements declarationsAndStatements;
     mixin OpEquals;
@@ -1344,8 +1348,9 @@ final class DeclarationOrStatement : BaseNode
 
     /** */ Declaration declaration;
     /** */ Statement statement;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
+    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -1462,12 +1467,13 @@ final class EnumBody : BaseNode
     /**
      * Byte position of the opening brace
      */
-    size_t startLocation;
+    size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
 
     /**
      * Byte position of the closing brace
      */
-    size_t endLocation;
+    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -1596,7 +1602,13 @@ final class ForStatement : BaseNode
     /** */ Expression test;
     /** */ Expression increment;
     /** */ DeclarationOrStatement declarationOrStatement;
-    /** */ size_t startIndex;
+    /** */ size_t parenOpenLocation() @property
+    {
+        return tokens.length > 1 ? tokens[1].index : size_t.init;
+    }
+
+    deprecated("use parenOpenLocation or tokens instead") alias startIndex = parenOpenLocation;
+
     mixin OpEquals;
 }
 
@@ -1617,11 +1629,19 @@ final class Foreach(bool declOnly) : BaseNode
     /** */ ForeachType foreachType;
     /** */ Expression low;
     /** */ Expression high;
-    /** */ size_t startIndex;
     static if (declOnly)
         /** */ Declaration[] declarations;
     else
         /** */ DeclarationOrStatement declarationOrStatement;
+
+    /** */ size_t parenOpenLocation() @property
+    {
+        enum startLocation = declOnly ? 2 : 1;
+        return tokens.length > startLocation ? tokens[startLocation].index : size_t.init;
+    }
+
+    deprecated("use parenOpenLocation or tokens instead") alias startIndex = parenOpenLocation;
+
     mixin OpEquals;
 }
 
@@ -1855,9 +1875,23 @@ final class IfStatement : BaseNode
     /** */ Expression expression;
     /** */ DeclarationOrStatement thenStatement;
     /** */ DeclarationOrStatement elseStatement;
-    /** */ size_t startIndex;
-    /** */ size_t line;
-    /** */ size_t column;
+    /** */ size_t parenOpenLocation() @property
+    {
+        return tokens.length > 1 ? tokens[1].index : size_t.init;
+    }
+
+    /** */ size_t line() @property
+    {
+        return tokens.length > 0 ? tokens[0].line : size_t.init;
+    }
+
+    /** */ size_t column() @property
+    {
+        return tokens.length > 0 ? tokens[0].column : size_t.init;
+    }
+
+    deprecated("use parenOpenLocation or tokens instead") alias startIndex = parenOpenLocation;
+
     mixin OpEquals;
 }
 
@@ -1894,8 +1928,19 @@ final class ImportDeclaration : BaseNode
     }
     /** */ SingleImport[] singleImports;
     /** */ ImportBindings importBindings;
-    /** */ size_t startIndex;
-    /** */ size_t endIndex;
+    /** */ size_t startIndex() @property
+    {
+        return tokens.length > 0 ? tokens[0].index : size_t.init;
+    }
+
+    /** */ size_t endIndex() @property
+    {
+        if (tokens.length == 0)
+            return size_t.init;
+        else // ";" token
+            return tokens[$ - 1].index + 1;
+    }
+
     mixin OpEquals;
 }
 
@@ -2043,8 +2088,9 @@ final class Invariant : BaseNode
     /** */ BlockStatement blockStatement;
     /** */ AssertArguments assertArguments;
     /** */ string comment;
-    size_t line;
-    size_t index;
+    /** */ size_t line() const @property { return tokens.length > 1 ? tokens[0].line : size_t.init; }
+    /** */ size_t index() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -2218,9 +2264,18 @@ final class ModuleDeclaration : BaseNode
     }
     /** */ Deprecated deprecated_;
     /** */ IdentifierChain moduleName;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
     /** */ string comment;
+    size_t startLocation() const @property
+    {
+        auto module_ = tokens.countUntil!(a => a.type == tok!"module");
+        if (module_ == -1)
+            return size_t.init;
+        else
+            return tokens[module_].index;
+    }
+
+    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -2308,8 +2363,9 @@ final class StatementNoCaseNoDefault : BaseNode
     /** */ VersionSpecification versionSpecification;
     /** */ DebugSpecification debugSpecification;
     /** */ ExpressionStatement expressionStatement;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
+    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -2555,8 +2611,9 @@ final class ReturnStatement : BaseNode
         mixin (visitIfNotNull!(expression));
     }
     /** */ Expression expression;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
+    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -2747,12 +2804,13 @@ final class StructBody : BaseNode
     /**
      * Byte position of the opening brace
      */
-    size_t startLocation;
+    size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
 
     /**
      * Byte position of the closing brace
      */
-    size_t endLocation;
+    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     /** */ Declaration[] declarations;
     mixin OpEquals;
 }
@@ -2780,8 +2838,9 @@ final class StructInitializer : BaseNode
         mixin (visitIfNotNull!(structMemberInitializers));
     }
     /** */ StructMemberInitializers structMemberInitializers;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
+    /** */ size_t startLocation() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+    /** */ size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -2918,7 +2977,8 @@ final class TemplateDeclaration : BaseNode
     /**
      * Byte position of the closing brace
      */
-    size_t endLocation;
+    size_t endLocation() const @property { return tokens.length > 1 ? tokens[$ - 1].index : size_t.init; }
+
     mixin OpEquals;
 }
 
@@ -3292,7 +3352,8 @@ final class VersionCondition : BaseNode
     {
         mixin (visitIfNotNull!(token));
     }
-    /** */ size_t versionIndex;
+    /** */ size_t versionIndex() const @property { return tokens.length > 1 ? tokens[0].index : size_t.init; }
+
     /** */ Token token;
     mixin OpEquals;
 }
@@ -3318,7 +3379,13 @@ final class WhileStatement : BaseNode
 
     /** */ Expression expression;
     /** */ DeclarationOrStatement declarationOrStatement;
-    /** */ size_t startIndex;
+    /** */ size_t parenOpenLocation() @property
+    {
+        return tokens.length > 1 ? tokens[1].index : size_t.init;
+    }
+
+    deprecated("use parenOpenLocation or tokens instead") alias startIndex = parenOpenLocation;
+
     mixin OpEquals;
 }
 

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -630,7 +630,7 @@ class Parser
                 node.isLabel = true;
                 if (currentIs(tok!";"))
                 {
-                node.tokens = tokens[startIndex .. index];
+                    node.tokens = tokens[startIndex .. index];
                     return node;
                 }
                 mixin(parseNodeQ!(`node.asmInstruction`, `AsmInstruction`));
@@ -2828,7 +2828,7 @@ class Parser
             node = allocator.make!EnumMemberAttribute;
             mixin(parseNodeQ!(`node.deprecated_`, `Deprecated`));
         }
-        node.tokens = tokens[startIndex .. index];
+        if (node) node.tokens = tokens[startIndex .. index];
         return node;
     }
 
@@ -3045,7 +3045,7 @@ class Parser
         auto startIndex = index;
         mixin(tokenCheck!"static");
         auto decl = parseForeach!true();
-        decl.tokens = tokens[startIndex .. index];
+        if (decl) decl.tokens = tokens[startIndex .. index];
         return decl;
     }
 
@@ -7210,7 +7210,7 @@ class Parser
             {
                 error("Error, expected parameters or `)`", false);
                 advance();
-                newUnary.tokens = tokens[startIndex .. index];
+                if (newUnary) newUnary.tokens = tokens[startIndex .. index];
                 return newUnary;
             }
             mixin (nullCheck!`newUnary.functionCallExpression = parseFunctionCallExpression(node)`);
@@ -8392,7 +8392,7 @@ protected: final:
                 node.comment ~= semicolon.trailingComment;
             }
         }
-        node.tokens = tokens[startIndex .. index];
+        if (node) node.tokens = tokens[startIndex .. index];
         return node;
     }
 
@@ -8430,7 +8430,7 @@ protected: final:
             advance();
         else
             mixin(parseNodeQ!(`node.functionBody`, `FunctionBody`));
-        node.tokens = tokens[startIndex .. index];
+        if (node) node.tokens = tokens[startIndex .. index];
         return node;
     }
 

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -327,11 +327,8 @@ class Parser
             error("argument list expected instead of EOF");
             return null;
         }
-        size_t startLocation = current().index;
         auto node = parseCommaSeparatedRule!(ArgumentList, AssignExpression)(true);
         mixin (nullCheck!`node`);
-        node.startLocation = startLocation;
-        if (moreTokens) node.endLocation = current().index;
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -371,7 +368,6 @@ class Parser
         auto node = allocator.make!ArrayInitializer;
         const open = expect(tok!"[");
         mixin (nullCheck!`open`);
-        node.startLocation = open.index;
         StackBuffer arrayMemberInitializations;
         while (moreTokens())
         {
@@ -387,7 +383,6 @@ class Parser
         ownArray(node.arrayMemberInitializations, arrayMemberInitializations);
         const close = expect(tok!"]");
         mixin (nullCheck!`close`);
-        node.endLocation = close.index;
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -1090,7 +1085,6 @@ class Parser
             error("`(`, or identifier expected");
             return null;
         }
-        node.startLocation = start.index;
         switch (current.type)
         {
         case tok!"identifier":
@@ -1115,7 +1109,6 @@ class Parser
             error("`(`, or identifier expected");
             return null;
         }
-        if (moreTokens) node.endLocation = current().index;
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -1305,18 +1298,14 @@ class Parser
         auto node = allocator.make!BlockStatement;
         const openBrace = expect(tok!"{");
         mixin (nullCheck!`openBrace`);
-        node.startLocation = openBrace.index;
         if (!currentIs(tok!"}"))
         {
             mixin(parseNodeQ!(`node.declarationsAndStatements`, `DeclarationsAndStatements`));
         }
         const closeBrace = expect(tok!"}");
-        if (closeBrace !is null)
-            node.endLocation = closeBrace.index;
-        else
+        if (closeBrace is null)
         {
             trace("Could not find end of block statement.");
-            node.endLocation = size_t.max;
         }
 
         node.tokens = tokens[startIndex .. index];
@@ -2391,8 +2380,6 @@ class Parser
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto startIndex = index;
         auto node = allocator.make!DeclarationOrStatement;
-        if (moreTokens)
-            node.startLocation = current.index;
         // "Any ambiguities in the grammar between Statements and
         // Declarations are resolved by the declarations taking precedence."
         immutable b = setBookmark();
@@ -2413,8 +2400,6 @@ class Parser
             goToBookmark(b);
             node.declaration = parseDeclaration(true, true);
         }
-        if (moreTokens)
-            node.endLocation = current.index;
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -2635,7 +2620,6 @@ class Parser
         EnumBody node = allocator.make!EnumBody;
         const open = expect(tok!"{");
         mixin (nullCheck!`open`);
-        node.startLocation = open.index;
         StackBuffer enumMembers;
         EnumMember last;
         while (moreTokens())
@@ -2673,9 +2657,7 @@ class Parser
                 error("Enum member expected");
         }
         ownArray(node.enumMembers, enumMembers);
-        const close = expect (tok!"}");
-        if (close !is null)
-            node.endLocation = close.index;
+        expect(tok!"}");
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -2995,8 +2977,6 @@ class Parser
         auto startIndex = index;
         auto node = allocator.make!ForStatement;
         mixin(tokenCheck!"for");
-        if (moreTokens)
-            node.startIndex = current().index;
         mixin(tokenCheck!"(");
 
         if (currentIs(tok!";"))
@@ -3089,8 +3069,6 @@ class Parser
             error("`foreach` or `foreach_reverse` expected");
             return null;
         }
-        if (moreTokens)
-            node.startIndex = current().index;
         mixin(tokenCheck!"(");
         ForeachTypeList feType = parseForeachTypeList();
         mixin (nullCheck!`feType`);
@@ -3717,11 +3695,7 @@ class Parser
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto startIndex = index;
         IfStatement node = allocator.make!IfStatement;
-        node.line = current().line;
-        node.column = current().column;
         mixin(tokenCheck!"if");
-        if (moreTokens)
-            node.startIndex = current().index;
         mixin(tokenCheck!"(");
         const b = setBookmark();
 
@@ -3882,7 +3856,6 @@ class Parser
     {
         auto startIndex = index;
         auto node = allocator.make!ImportDeclaration;
-        node.startIndex = current().index;
         mixin(tokenCheck!"import");
         SingleImport si = parseSingleImport();
         if (si is null)
@@ -3917,7 +3890,6 @@ class Parser
             }
             ownArray(node.singleImports, singleImports);
         }
-        node.endIndex = (moreTokens() ? current() : previous()).index + 1;
         mixin(tokenCheck!";");
         node.tokens = tokens[startIndex .. index];
         return node;
@@ -4161,8 +4133,6 @@ class Parser
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto startIndex = index;
         auto node = allocator.make!Invariant;
-        node.index = current.index;
-        node.line = current.line;
         mixin(tokenCheck!"invariant");
         bool mustHaveBlock;
         if (currentIs(tok!"(") && peekIs(tok!")"))
@@ -4595,10 +4565,7 @@ class Parser
         if (node.comment is null)
             node.comment = start.trailingComment;
         comment = null;
-        const end = expect(tok!";");
-        node.startLocation = start.index;
-        if (end !is null)
-            node.endLocation = end.index;
+        expect(tok!";");
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -5407,12 +5374,10 @@ class Parser
         auto node = allocator.make!ReturnStatement;
         const start = expect(tok!"return");
         mixin(nullCheck!`start`);
-        node.startLocation = start.index;
         if (!currentIs(tok!";"))
             mixin(parseNodeQ!(`node.expression`, `Expression`));
         const semicolon = expect(tok!";");
         mixin(nullCheck!`semicolon`);
-        node.endLocation = semicolon.index;
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -5637,7 +5602,6 @@ class Parser
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto startIndex = index;
         auto node = allocator.make!StatementNoCaseNoDefault;
-        node.startLocation = current().index;
         switch (current.type)
         {
         case tok!"{":
@@ -5744,7 +5708,6 @@ class Parser
             mixin(parseNodeQ!(`node.expressionStatement`, `ExpressionStatement`));
             break;
         }
-        node.endLocation = tokens[index - 1].index;
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -5914,7 +5877,6 @@ class Parser
         auto startIndex = index;
         auto node = allocator.make!StructBody;
         const start = expect(tok!"{");
-        if (start !is null) node.startLocation = start.index;
         StackBuffer declarations;
         while (!currentIs(tok!"}") && moreTokens())
         {
@@ -5923,8 +5885,7 @@ class Parser
                 allocator.rollback(c);
         }
         ownArray(node.declarations, declarations);
-        const end = expect(tok!"}");
-        if (end !is null) node.endLocation = end.index;
+        expect(tok!"}");
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -5988,10 +5949,8 @@ class Parser
         auto node = allocator.make!StructInitializer;
         const a = expect(tok!"{");
         mixin (nullCheck!`a`);
-        node.startLocation = a.index;
         if (currentIs(tok!"}"))
         {
-            node.endLocation = current.index;
             advance();
         }
         else
@@ -5999,7 +5958,6 @@ class Parser
             mixin(parseNodeQ!(`node.structMemberInitializers`, `StructMemberInitializers`));
             const e = expect(tok!"}");
             mixin (nullCheck!`e`);
-            node.endLocation = e.index;
         }
         node.tokens = tokens[startIndex .. index];
         return node;
@@ -6287,7 +6245,6 @@ class Parser
         }
         ownArray(node.declarations, declarations);
         const end = expect(tok!"}");
-        if (end !is null) node.endLocation = end.index;
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -7413,7 +7370,6 @@ class Parser
         auto node = allocator.make!VersionCondition;
         const v = expect(tok!"version");
         mixin(nullCheck!`v`);
-        node.versionIndex = v.index;
         mixin(tokenCheck!"(");
         if (currentIsOneOf(tok!"intLiteral", tok!"identifier", tok!"unittest", tok!"assert"))
             node.token = advance();
@@ -7465,8 +7421,6 @@ class Parser
         auto startIndex = index;
         auto node = allocator.make!WhileStatement;
         mixin(tokenCheck!"while");
-        if (moreTokens)
-            node.startIndex = current().index;
         mixin(tokenCheck!"(");
         mixin(parseNodeQ!(`node.expression`, `Expression`));
         mixin(tokenCheck!")");


### PR DESCRIPTION
fix #191

All nodes now contain a `const(Token)[] tokens` which is a slice of the input tokens which contains all the tokens which were parsed for that AST node.

The first commit simply adds the tokens array to each type

The second commit replaces old startIndex/startLocation and endIndex/endLocation with getter properties dynamically getting from the tokens array. It is not fully backwards compatible as before the user could set the value and now only getting works. However they should all return the same values as in previous versions.