### PR TITLE
Fix performance regression in CI due to slow setup of Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+
+dist: xenial
 sudo: false
 language: d
 d:
@@ -19,8 +21,7 @@ matrix:
           - libevent-dev
 
 install:
-  - pyenv install 3.6.3
-  - pyenv global system 3.6.3
+  - sudo apt-get install python3-pip python3-setuptools
   - pip3 install 'meson==0.48.2'
   - mkdir .ntmp
   - curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o .ntmp/ninja-linux.zip


### PR DESCRIPTION
When Ubuntu xenial is selected, Python 3.5 is already there which is good enough for Meson.