### PR TITLE
fix #338 - A class Inheriting from an AliasSeq item is seen as an error

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -181,7 +181,6 @@ abstract class ASTVisitor
     /** */ void visit(const AutoDeclarationPart autoDeclarationPart) { autoDeclarationPart.accept(this); }
     /** */ void visit(const BlockStatement blockStatement) { blockStatement.accept(this); }
     /** */ void visit(const BreakStatement breakStatement) { breakStatement.accept(this); }
-    /** */ void visit(const BaseClass baseClass) { baseClass.accept(this); }
     /** */ void visit(const BaseClassList baseClassList) { baseClassList.accept(this); }
     /** */ void visit(const CaseRangeStatement caseRangeStatement) { caseRangeStatement.accept(this); }
     /** */ void visit(const CaseStatement caseStatement) { caseStatement.accept(this); }
@@ -991,24 +990,13 @@ final class BreakStatement : BaseNode
 }
 
 ///
-final class BaseClass : BaseNode
-{
-    override void accept(ASTVisitor visitor) const
-    {
-        mixin (visitIfNotNull!(type2));
-    }
-    /** */ Type2 type2;
-    mixin OpEquals;
-}
-
-///
 final class BaseClassList : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
         mixin (visitIfNotNull!(items));
     }
-    /** */ BaseClass[] items;
+    /** */ Type[] items;
     mixin OpEquals;
 }
 

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -560,15 +560,6 @@ class Formatter(Sink)
         put(";");
     }
 
-    void format(const BaseClass baseClass)
-    {
-        debug(verbose) writeln("BaseClass");
-        with(baseClass)
-        {
-            if (type2) format(type2);
-        }
-    }
-
     void format(const BaseClassList baseClassList)
     {
         debug(verbose) writeln("BaseClassList");

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -1356,43 +1356,16 @@ class Parser
     }
 
     /**
-     * Parses a BaseClass
-     *
-     * $(GRAMMAR $(RULEDEF baseClass):
-     *     $(RULE type2)
-     *     ;)
-     */
-    BaseClass parseBaseClass()
-    {
-        mixin(traceEnterAndExit!(__FUNCTION__));
-        auto startIndex = index;
-        auto node = allocator.make!BaseClass;
-        if (!moreTokens)
-            return null;
-        if (current.type.isProtection())
-        {
-            warn("Use of base class protection is deprecated.");
-            advance();
-        }
-        if ((node.type2 = parseType2()) is null)
-        {
-            return null;
-        }
-        node.tokens = tokens[startIndex .. index];
-        return node;
-    }
-
-    /**
      * Parses a BaseClassList
      *
      * $(GRAMMAR $(RULEDEF baseClassList):
-     *     $(RULE baseClass) ($(LITERAL ',') $(RULE baseClass))*
+     *     $(RULE type) ($(LITERAL ',') $(RULE type))*
      *     ;)
      */
     BaseClassList parseBaseClassList()
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
-        return parseCommaSeparatedRule!(BaseClassList, BaseClass)();
+        return parseCommaSeparatedRule!(BaseClassList, Type)();
     }
 
     /**
@@ -3593,6 +3566,8 @@ class Parser
             expect(tok!"]");
             if (!currentIs(tok!"."))
             {
+                // goes back and consider the indexer as a type suffix giving
+                // a static array dim.
                 if (node.indexer !is null)
                 {
                     allocator.rollback(c);

--- a/test/pass_files/classes.d
+++ b/test/pass_files/classes.d
@@ -1,11 +1,11 @@
 class A;
 class B {}
 class C : B {}
+class C : StaticSeq[0] {}
 class D(T) if (Z) : B {}
 class E(T) : B if (Z) {}
 class F(T);
 class G(T) if (Z);
-class H : public A {}
 class H : typeof(A).B {}
 class I { int x; alias y = this.x; }
 class J : K { int x; alias y = super.x; }


### PR DESCRIPTION
`BaseClass` contained a `Type2` so the indexer, since not followed by a `.` was not parsed. Only `Type` can have an indexer followed by nothing. Also get rid of the `BaseClass` node since it was a useless indirection.