### PR TITLE
fix wrong rule in parseVariableDeclaration

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -7306,7 +7306,6 @@ class Parser
      *
      * $(GRAMMAR $(RULEDEF variableDeclaration):
      *       $(RULE storageClass)* $(RULE _type) $(RULE declarator) ($(LITERAL ',') $(RULE declarator))* $(LITERAL ';')
-     *     | $(RULE storageClass)* $(RULE _type) $(LITERAL identifier) $(LITERAL '=') $(RULE functionBody) $(LITERAL ';')
      *     | $(RULE autoDeclaration)
      *     ;)
      */

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -7333,8 +7333,6 @@ class Parser
         node.comment = comment;
         comment = null;
 
-        // TODO: handle function bodies correctly
-
         StackBuffer declarators;
         Declarator last;
         while (true)


### PR DESCRIPTION
Nothing here was done that followed the rule that's removed.