### PR TITLE
fix #338 - A class Inheriting from an AliasSeq item is seen as an error

### DIFF
--- a/test/fail_files/misc_coverage.d
+++ b/test/fail_files/misc_coverage.d
@@ -67,5 +67,7 @@ __vector) a;
 __vector() a;
 __vector(__vector) a;
 
+class A : SomeDynarray[] {}
+
 //keep at the end
 void foo(){a +=

--- a/test/pass_files/classes.d
+++ b/test/pass_files/classes.d
@@ -1,6 +1,8 @@
 class A;
 class B {}
 class C : B {}
+class C : TList[0] {}
+class C : TList[0].TList[0].Prop {}
 class D(T) if (Z) : B {}
 class E(T) : B if (Z) {}
 class F(T);


### PR DESCRIPTION
The official grammar pretended that the indexer of a `TypeIdentifierPart` (called over there an `IdentifierList`) is always followed by another dotted part, which was wrong.

DMD already did the right fix in its parser but the specs were wrong and misled me in an older PR (#159).
The change to the official spec is [here](https://github.com/dlang/dlang.org/pull/2556).