### PR TITLE
Allow the declarations that follows a block with errors to be in the right scope

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -2368,6 +2368,11 @@ class Parser
                 allocator.rollback(c);
                 if (suppressMessages > 0)
                     return null;
+                // better for DCD, if the end of the block is reached then
+                // go back, allowing the following declarations to be in
+                // the right scope, instead of the block we were in.
+                if (index > 0 && previous == tok!"}")
+                    index -= 1;
             }
         }
         ownArray(node.declarationsAndStatements, declarationsAndStatements);

--- a/test/fail_files/better_block_leave.d
+++ b/test/fail_files/better_block_leave.d
@@ -1,0 +1,6 @@
+void foo()
+{
+    c =
+}
+
+alias b this;


### PR DESCRIPTION
This is required to fix https://github.com/dlang-community/D-Scanner/issues/738.