### PR TITLE
update the version of stdx allocs used when building with Meson

### DIFF
--- a/subprojects/stdx-allocator.wrap
+++ b/subprojects/stdx-allocator.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = stdx-allocator
 url       = https://github.com/dlang-community/stdx-allocator.git
-revision  = v2.77.4
+revision  = v2.77.5


### PR DESCRIPTION
required since 2.085 changes to GC