### PR TITLE
Fix index/startIndex typo

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -5481,7 +5481,7 @@ class Parser
         mixin(tokenCheck!"shared");
         mixin(tokenCheck!"static");
         mixin(tokenCheck!"~");
-        return parseStaticCtorDtorCommon(node, index);
+        return parseStaticCtorDtorCommon(node, startIndex);
     }
 
     /**


### PR DESCRIPTION
Due to this, `SharedStaticDesctructor` nodes only have a reference to a part of their tokens; the `shared`, `static` and `~` don't get inserted in `node.tokens`.