### PR TITLE
fix #360 - parse error when `body` is used in expression

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -5252,8 +5252,6 @@ class Parser
             node.dot = advance();
             goto case;
         case tok!"identifier":
-            if (current.text == "body")
-                goto case tok!"do";
             if (peekIs(tok!"=>"))
                 mixin(parseNodeQ!(`node.functionLiteralExpression`, `FunctionLiteralExpression`));
             else

--- a/test/pass_files/expressions.d
+++ b/test/pass_files/expressions.d
@@ -87,4 +87,5 @@ void foo()
 	(cast(Node*) data.ptr).next = null;
 	int[int[string]] aa5 = [["a":1]:2, ["b":3]:4];
 	if (is(typeof(a) == __vector)){}
+	Hand h = body.hands.left;
 }


### PR DESCRIPTION
Function literals beginning with `do` are broken anyway (https://issues.dlang.org/show_bug.cgi?id=19869)