### PR TITLE
fix #353 - Syntax error on templatized variable declarations

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -2318,10 +2318,19 @@ class Parser
                     error("no identifier for declarator");
                 return null;
             }
-            if (peekIs(tok!"("))
-                mixin (nullCheck!`node.functionDeclaration = parseFunctionDeclaration(t, false)`);
-            else
-                mixin (nullCheck!`node.variableDeclaration = parseVariableDeclaration(t, false)`);
+            const b2 = setBookmark();
+            node.variableDeclaration = parseVariableDeclaration(t, false);
+            if (node.variableDeclaration is null)
+            {
+                goToBookmark(b2);
+                node.functionDeclaration = parseFunctionDeclaration(t, false);
+            }
+            else abandonBookmark(b2);
+            if (!node.variableDeclaration && !node.functionDeclaration)
+            {
+                error("invalid variable declaration or function declaration", false);
+                return null;
+            }
             break;
         case tok!"version":
             if (peekIs(tok!"("))

--- a/test/pass_files/declarations.d
+++ b/test/pass_files/declarations.d
@@ -97,8 +97,12 @@ __traits(getMember, Foo, "Bar") fooBar;
 const(__traits(getMember, Foo, "Bar")) fooBar;
 alias FooBar = __traits(getMember, Foo, "Bar");
 const fooBar = cast(__traits(getMember, Foo, "Bar")) __traits(getMember, Foo, "bar");
+int twice(int x) = 2 * x;
+const int twice(int x) = 2 * x;
+immutable int twice(int x) = 2 * x;
 
 void foo()
 {
     __traits(getMember, Foo, "Bar") fooBar;
+    immutable int twice(int x) = 2 * x;
 }


### PR DESCRIPTION
Looking for a left paren following `Type Identifier` was not sufficient to determine if the declaration is a func or a var.