### PR TITLE
Fix trace(string) built with version=dparse_verbose

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -8414,7 +8414,7 @@ protected: final:
         import std.stdio : stderr;
         void trace(string message)
         {
-            if (suppressMessages > 0)
+            if (!suppressMessages.empty)
                 return;
             auto depth = format("%4d ", _traceDepth);
             if (index < tokens.length)


### PR DESCRIPTION
suppressMessages was changed in 95c31d5a444a3c55d59a5f9a8b4378d48bdf23a1.

Should probably change the tag `v0.13.2` as well