### PR TITLE
Change RollbackAllocator.Node.contains to exclusive end

### DIFF
--- a/src/dparse/rollback_allocator.d
+++ b/src/dparse/rollback_allocator.d
@@ -66,7 +66,7 @@ public:
         }
         else
             assert(contains(point), "Attepmted to roll back to a point not in the allocator.");
-        while (!first.contains(point))
+        while (first !is null && !first.contains(point))
             deallocateNode();
         assert(first !is null);
         immutable begin = point - cast(size_t) first.mem.ptr;
@@ -122,7 +122,7 @@ private:
 
         bool contains(size_t p) const pure nothrow @nogc @safe
         {
-            return p >= cast(size_t) mem.ptr && p <= cast(size_t) mem.ptr + mem.length;
+            return p >= cast(size_t) mem.ptr && p < cast(size_t) mem.ptr + mem.length;
         }
     }
 


### PR DESCRIPTION
This fixes an issue in rollback(point) that the assert(contains(point)) would not error out but then it would crash eventually because first becomes null while recursively checking the contains.

Before it would keep deallocating even when the memory point we have is right outside the allocated memory region.

This shouldn't introduce any side effects as contains is only used in the rollback_allocator module and now it would simply assert out instead of segfaulting out.

(got libdparse to segfault in the rollback call in parseFunctionBody and this changes it to an assert fail but I'm still searching for the reason why it is invalid in the first place)