### PR TITLE
Fix rollback_allocator implementation

### DIFF
--- a/src/dparse/rollback_allocator.d
+++ b/src/dparse/rollback_allocator.d
@@ -9,6 +9,9 @@ struct RollbackAllocator
 {
 public:
 
+    // must be multiple of 8
+    enum memoryAlignment = 16u;
+
     @disable this(this);
 
     ~this()
@@ -27,12 +30,14 @@ public:
     }
     do
     {
+        import std.algorithm.comparison : min;
+
         if (first is null)
             allocateNode(size);
 
-        // Move size up to the next multiple of 8 for memory alignment purposes
-        immutable size_t s = size & ~7UL;
-        immutable size_t s2 = s == size ? size : s + 8;
+        // Memory align the size
+        immutable size_t s = size & ~(cast(size_t) memoryAlignment - 1);
+        immutable size_t s2 = s == size ? size : s + memoryAlignment;
 
         size_t fu = first.used;
         size_t end = fu + s2;
@@ -47,7 +52,8 @@ public:
         //assert((cast(size_t) first.mem.ptr) % 8 == 0);
         //assert(((cast(size_t) first.mem.ptr) + end) % 8 == 0);
         void[] m = first.mem[fu .. fu + size];
-        first.used = end;
+        // alignment can make our size here bigger than what we actually have, so we clamp down to the used amount
+        first.used = min(end, first.mem.length);
         return m;
     }
 
@@ -66,7 +72,7 @@ public:
         }
         else
             assert(contains(point), "Attepmted to roll back to a point not in the allocator.");
-        while (!first.contains(point))
+        while (first !is null && !first.contains(point))
             deallocateNode();
         assert(first !is null);
         immutable begin = point - cast(size_t) first.mem.ptr;
@@ -81,7 +87,7 @@ public:
      */
     size_t setCheckpoint() const nothrow @nogc
     {
-        assert(first.used <= first.mem.length);
+        assert(first is null || first.used <= first.mem.length);
         return first is null ? 0 : cast(size_t) first.mem.ptr + first.used;
     }
 
@@ -128,13 +134,17 @@ private:
 
     void allocateNode(size_t size)
     {
+        import core.exception : onOutOfMemoryError;
         import std.algorithm : max;
-        import stdx.allocator.mallocator : Mallocator;
         import std.conv : emplace;
+        import stdx.allocator.mallocator : AlignedMallocator;
 
         enum ALLOC_SIZE = 1024 * 8;
 
-        ubyte[] m = cast(ubyte[]) Mallocator.instance.allocate(max(size + Node.sizeof, ALLOC_SIZE));
+        ubyte[] m = cast(ubyte[]) AlignedMallocator.instance.alignedAllocate(max(size + Node.sizeof, ALLOC_SIZE), memoryAlignment);
+        if (m is null)
+            onOutOfMemoryError();
+
         version (debug_rollback_allocator)
             m[] = 0;
         Node* n = emplace!Node(cast(Node*) m.ptr, first, 0, m[Node.sizeof .. $]);
@@ -145,15 +155,87 @@ private:
     void deallocateNode()
     {
         assert(first !is null);
-        import stdx.allocator.mallocator : Mallocator;
+        import stdx.allocator.mallocator : AlignedMallocator;
 
         Node* next = first.next;
         ubyte[] mem = (cast(ubyte*) first)[0 .. Node.sizeof + first.mem.length];
         version (debug_rollback_allocator)
             mem[] = 0;
-        Mallocator.instance.deallocate(mem);
+        AlignedMallocator.instance.deallocate(mem);
         first = next;
     }
 
     Node* first;
+}
+
+@("most simple usage, including memory across multiple pointers")
+unittest
+{
+    RollbackAllocator rba;
+    size_t[10] checkpoint;
+    foreach (i; 0 .. 10)
+    {
+        checkpoint[i] = rba.setCheckpoint();
+        rba.allocate(4000);
+    }
+
+    foreach_reverse (i; 0 .. 10)
+    {
+        rba.rollback(checkpoint[i]);
+    }
+}
+
+@("many allocates and frees while leaking memory")
+unittest
+{
+    RollbackAllocator rba;
+    foreach (i; 0 .. 10)
+    {
+        size_t[3] checkpoint;
+        foreach (n; 0 .. 3)
+        {
+            checkpoint[n] = rba.setCheckpoint();
+            rba.allocate(4000);
+        }
+        foreach_reverse (n; 1 .. 3)
+        {
+            rba.rollback(checkpoint[n]);
+        }
+    }
+}
+
+@("allocating overly big")
+unittest
+{
+    import std.stdio : stderr;
+
+    RollbackAllocator rba;
+    size_t[200] checkpoint;
+    size_t cp;
+    foreach (i; 1024 * 8 - 100 .. 1024 * 8 + 100)
+    {
+        try
+        {
+            checkpoint[cp++] = rba.setCheckpoint();
+            rba.allocate(i);
+        }
+        catch (Error e)
+        {
+            stderr.writeln("Unittest: crashed in allocating ", i, " bytes");
+            throw e;
+        }
+    }
+
+    foreach_reverse (i, c; checkpoint[0 .. cp])
+    {
+        try
+        {
+            rba.rollback(c);
+        }
+        catch (Error e)
+        {
+            stderr.writeln("Unittest: crashed in rolling back ", i, " (address ", c, ")");
+            throw e;
+        }
+    }
 }

--- a/src/dparse/rollback_allocator.d
+++ b/src/dparse/rollback_allocator.d
@@ -72,9 +72,12 @@ public:
         }
         else
             assert(contains(point), "Attepmted to roll back to a point not in the allocator.");
+
+        // while `first !is null` is always going to pass after the contains(point) check, it may no longer pass after deallocateNode
         while (first !is null && !first.contains(point))
             deallocateNode();
         assert(first !is null);
+
         immutable begin = point - cast(size_t) first.mem.ptr;
         version (debug_rollback_allocator)
             (cast(ubyte[]) first.mem)[begin .. $] = 0;


### PR DESCRIPTION
Uses AlignedMallocator instead of Mallocator to guarantee memory alignment (and avoid "The memoriez" assert error)

Throws `out of memory` now whenever the allocator returns null.

Fixes rollback bug with over-allocation.

Fixes some null checks in code and asserts.

Added unittests for usage which the previous rollback allocator didn't pass.

(this fixes a lot of seemingly random crashes and bugs with big files)