### PR TITLE
Fix #390 - Error for opaque enum with base type

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -2831,16 +2831,16 @@ class Parser
         mixin (tokenCheck!(`node.name`, `identifier`));
         node.comment = comment;
         comment = null;
+        if (currentIs(tok!":"))
+        {
+            advance(); // skip ':'
+            mixin(parseNodeQ!(`node.type`, `Type`));
+        }
         if (currentIs(tok!";"))
         {
             advance();
             node.tokens = tokens[startIndex .. index];
             return node;
-        }
-        if (currentIs(tok!":"))
-        {
-            advance(); // skip ':'
-            mixin(parseNodeQ!(`node.type`, `Type`));
         }
         mixin(parseNodeQ!(`node.enumBody`, `EnumBody`));
         node.tokens = tokens[startIndex .. index];

--- a/test/pass_files/enums.d
+++ b/test/pass_files/enums.d
@@ -18,3 +18,7 @@ enum E
     @A @B deprecated("meep") member,
     deprecated("meep") member
 }
+
+// https://github.com/dlang-community/libdparse/issues/390
+enum F;
+enum G : long;


### PR DESCRIPTION
`:` can never appear after `;`, only before.