### PR TITLE
Fix #397 - extern(C++, ...) only supports identifiers

### DIFF
--- a/test/pass_files/linkageAttributes.d
+++ b/test/pass_files/linkageAttributes.d
@@ -9,3 +9,8 @@ extern(C++) int g;
 extern(C++, a.b.c) int h;
 extern(C++, struct) int i;
 extern(C++, class) int j;
+
+extern(C++, "abc") int k;
+extern(C++, "a", "b", "c") int k;
+extern(C++, (abc)) int m;
+extern(C++, ("abc")) int n;


### PR DESCRIPTION
Implemented according to the grammar defined in the [pending spec PR](https://github.com/dlang/dlang.org/pull/2716)