### PR TITLE
Handle empty doc comments ("///") on unittests

### DIFF
--- a/src/dparse/trivia.d
+++ b/src/dparse/trivia.d
@@ -568,6 +568,9 @@ void main() {
     writeln(":)");
 }
 
+///
+unittest {}
+
 /// end of file`;
 
     LexerConfig cf;
@@ -575,7 +578,7 @@ void main() {
 
     const tokens = getTokensForParser(src, cf, &ca);
 
-    assert(tokens.length == 19);
+    assert(tokens.length == 22);
 
     assert(tokens[0].type == tok!"module");
     assert(tokens[0].leadingTrivia.length == 6);
@@ -694,9 +697,30 @@ void main() {
 
     assert(tokens[18].type == tok!"}");
     assert(!tokens[18].leadingTrivia.length);
-    assert(tokens[18].trailingTrivia.length == 2);
+    assert(tokens[18].trailingTrivia.length == 1);
     assert(tokens[18].trailingTrivia[0].type == tok!"whitespace");
     assert(tokens[18].trailingTrivia[0].text == "\n\n");
-    assert(tokens[18].trailingTrivia[1].type == tok!"comment");
-    assert(tokens[18].trailingTrivia[1].text == "/// end of file");
+
+    assert(tokens[19].type == tok!"unittest");
+    assert(tokens[19].leadingTrivia.length == 2);
+    assert(tokens[19].leadingTrivia[0].type == tok!"comment");
+    assert(tokens[19].leadingTrivia[0].text == "///");
+    assert(tokens[19].leadingTrivia[1].type == tok!"whitespace");
+    assert(tokens[19].leadingTrivia[1].text == "\n");
+
+    assert(tokens[19].trailingTrivia.length == 1);
+    assert(tokens[19].trailingTrivia[0].type == tok!"whitespace");
+    assert(tokens[19].trailingTrivia[0].text == " ");
+
+    assert(tokens[20].type == tok!"{");
+    assert(!tokens[20].leadingTrivia.length);
+    assert(!tokens[20].trailingTrivia.length);
+
+    assert(tokens[21].type == tok!"}");
+    assert(!tokens[21].leadingTrivia.length);
+    assert(tokens[21].trailingTrivia.length == 2);
+    assert(tokens[21].trailingTrivia[0].type == tok!"whitespace");
+    assert(tokens[21].trailingTrivia[0].text == "\n\n");
+    assert(tokens[21].trailingTrivia[1].type == tok!"comment");
+    assert(tokens[21].trailingTrivia[1].text == "/// end of file");
 }


### PR DESCRIPTION
Currently there is no way to differentiate between the following unittests because `unittest.comment` is `null` for both:

```
unittest {}

///
unittest {}
```

This PR ensures that `comment` is non-`null` if a declaration has an empty doc comment.