### PR TITLE
Fix #53 - Support GDC extended asm syntax

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -804,7 +804,7 @@ final class AsmStatement : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(asmInstructions, gccAsmInstructions));
+        mixin (visitIfNotNull!(functionAttributes, asmInstructions, gccAsmInstructions));
     }
     /** */ AsmInstruction[] asmInstructions;
     /** */ GccAsmInstruction[] gccAsmInstructions;

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -3855,8 +3855,9 @@ unittest // Support GCC-sytle asm statements
                 assert(constraint.type == tok!"stringLiteral");
                 assert(constraint.text == `"=r"`);
 
-                // assert(expression.type == tok!"identifier");
-                // assert(expression.text == "var1");
+                auto una = cast(UnaryExpression) expression;
+                assert(una);
+                assert(una.primaryExpression.identifierOrTemplateInstance.identifier.text == "var1");
             }
         }
     }
@@ -3879,8 +3880,9 @@ unittest // Support GCC-sytle asm statements
                 assert(constraint.type == tok!"stringLiteral");
                 assert(constraint.text == `"=w"`);
 
-                // assert(expression.type == tok!"identifier");
-                // assert(expression.text == "var2");
+                auto una = cast(UnaryExpression) expression;
+                assert(una);
+                assert(una.primaryExpression.identifierOrTemplateInstance.identifier.text == "var2");
             }
 
             with (inputOperands.items[1])
@@ -3888,8 +3890,9 @@ unittest // Support GCC-sytle asm statements
                 assert(constraint.type == tok!"stringLiteral");
                 assert(constraint.text == `"g"`);
 
-                // assert(expression.type == tok!"identifier");
-                // assert(expression.text == "var3");
+                auto una = cast(UnaryExpression) expression;
+                assert(una);
+                assert(una.primaryExpression.identifierOrTemplateInstance.identifier.text == "var3");
             }
         }
     }

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -8200,6 +8200,15 @@ protected: final:
         }
     }
 
+    /// Skips token if present and returns whether token was skipped
+    bool skip(IdType token)
+    {
+        const found = currentIs(token);
+        if (found)
+            advance();
+        return found;
+    }
+
     void skip(alias O, alias C)()
     {
         assert (currentIs(O), current().text);

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3696,8 +3696,6 @@ class Parser
     GccAsmOperand parseGccAsmOperand()
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
-        if (currentIsOneOf(tok!":", tok!";"))
-            return null;
 
         const startIndex = index;
         auto node = allocator.make!GccAsmOperand();

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3643,10 +3643,22 @@ class Parser
 
                     if (skip(tok!":"))
                     {
-                        if (node.outputOperands.items.length)
-                            error("goto-labels only allowed without output operands!", false);
+                        size_t cp;
 
+                        if (node.outputOperands.items.length)
+                        {
+                            error("goto-labels only allowed without output operands!", false);
+                            cp = allocator.setCheckpoint();
+                        }
+
+                        // Parse even with the error above for better error reporting
                         mixin(parseNodeQ!("node.gotos", "DeclaratorIdentifierList"));
+
+                        if (cp)
+                        {
+                            allocator.rollback(cp);
+                            return null;
+                        }
                     }
                 }
             }
@@ -3659,9 +3671,9 @@ class Parser
     /**
      * Parses a GccAsmOperandList
      *
-     * $(GRAMMAR $(RULEDEF gccAsmOperandList)
+     * $(GRAMMAR $(RULEDEF gccAsmOperandList):
      *     ($(RULE gccAsmOperand) ($(LITERAL ',') $(RULE gccAsmOperand))* )?
-     * )
+     *     ;)
      */
     GccAsmOperandList parseGccAsmOperandList()
     {
@@ -3677,9 +3689,9 @@ class Parser
     /**
      * Parses a GccAsmOperand
      *
-     * $(GRAMMAR $(RULEDEF gccAsmOperand)
+     * $(GRAMMAR $(RULEDEF gccAsmOperand):
      *     ($(LITERAL '[') $(RULE identifier) $(LITERAL ']'))? $(RULE stringLiteral) $(LITERAL '(') $(RULE assignExpression) $(LITERAL ')')
-     * )
+     *     ;)
      */
     GccAsmOperand parseGccAsmOperand()
     {

--- a/test/fail_files/asm-gcc.d
+++ b/test/fail_files/asm-gcc.d
@@ -1,0 +1,21 @@
+void main()
+{
+    asm
+    {
+        "mov A B";
+        ;
+        "mov A B" : (a);
+        "mov A B" : xx "rw" (a);
+
+        "mov A B" : "rw" (a), ;
+        "mov A B" : "rw" (a), : ;
+        "mov A B" : "rw" (a) : , : ;
+
+        "mov A B" : "rw" (a) : "r" (b) : this;
+
+
+        "mov A B" : "rw" (a) : "r" (b) : "xxx" : 0;
+
+        "mov A B" : "rw" (a) : "r" (b) : "xxx" : LEnd ;
+    }
+}

--- a/test/pass_files/asm-gcc.d
+++ b/test/pass_files/asm-gcc.d
@@ -1,0 +1,55 @@
+module asm_gcc;
+
+ref T store(T)();
+
+enum asm1 = "mov %0, %0;";
+string asm2(int i) { return "mov %0, %0;"; }
+
+void main()
+{
+    int var1, var2, var3, var4;
+    int* ptr1;
+
+    asm
+    {
+        // Some tests as found in dmd's iasmgcc.d
+        "nop";
+        asm1;
+        asm2();
+        mixin(`"repne"`, `~ "scasb"`);
+
+        // GCC examples
+        "notl %[iov]" : [iov] "=r" (var1) : "0" (var2)   ;
+        ;
+        "mov %1, %0\n\t"
+        "add $1, %0" : "=r" (var1) : "r" (var2)   ;
+
+        // DRuntime
+        "cpuid" : "=a" (var1), "=c" (var2), "=d" (var3) : "a" (0x8000_0006) : "ebx"    ;
+
+        // Deprecated: Missing parens
+        "cpuid" : "=a" var1, "=b" var2 : "a" 0x8000_001E : "ecx", "edx";
+
+        "str x29, %0" : "=m" (var1)    ;
+
+        "mrs %0, cntvct_el0" : "=r" *ptr1;
+
+        "mov %1, %0" :  : "r" (var2) : "cc" : LCarry ;
+        "mov %0, %0" :  : "r" (var2) : "cc" ;
+
+        "mov %0, %0" : "=r" (*ptr1) : "r" (store!int = 1) : "cc";
+    }
+
+    LCarry:
+    asm  /*goto*/ {
+        "btl %1, %0\n\t"
+        "jc %l2"
+        : /* No outputs. */
+        : "r" (var1), "r" (var2)
+        : "cc"
+        : LCarry
+        ;
+    }
+
+    asm { "jmp LCarry" : : : : LCarry ; }
+}

--- a/test/pass_files/asm-gcc.d
+++ b/test/pass_files/asm-gcc.d
@@ -51,5 +51,9 @@ void main()
         ;
     }
 
-    asm { "jmp LCarry" : : : : LCarry ; }
+    asm {
+        ;
+        ;
+        "jmp LCarry" : : : : LCarry ;
+    }
 }

--- a/test/pass_files/asm-gcc.d
+++ b/test/pass_files/asm-gcc.d
@@ -15,7 +15,7 @@ void main()
         // Some tests as found in dmd's iasmgcc.d
         "nop";
         asm1;
-        asm2();
+        asm2(1);
         mixin(`"repne"`, `~ "scasb"`);
 
         // GCC examples


### PR DESCRIPTION
This should already work for all "pure" GCC style `asm`-statements but probably needs to be revised against gdc (which is more permissive in certain aspects). Mostly looking for feedback regarding the generated AST.

~~WIP because this still needs some cleanup and mabye more test coverage.~~

TODO:
- [x] More reliable detection of GCC asm
- [x] Support arbitrary expressions as assmembler templates, not only strings
- [x] Issue deprecation warning for missing parantheses around operands