### PR TITLE
Use the LPAREN and RPAREN macros in gcc asm grammar

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3688,7 +3688,7 @@ class Parser
      * Parses a GccAsmOperand
      *
      * $(GRAMMAR $(RULEDEF gccAsmOperand):
-     *     ($(LITERAL '[') $(RULE identifier) $(LITERAL ']'))? $(RULE stringLiteral) $(LITERAL '(') $(RULE assignExpression) $(LITERAL ')')
+     *     ($(LITERAL '[') $(RULE identifier) $(LITERAL ']'))? $(RULE stringLiteral) $(LITERAL '$(LPAREN)') $(RULE assignExpression) $(LITERAL '$(RPAREN)')
      *     ;)
      */
     GccAsmOperand parseGccAsmOperand()


### PR DESCRIPTION
You can see the problem here: https://libdparse.dlang.io/grammar.html#gccAsmOperand