### PR TITLE
Normalize namespace list grammar syntax

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4864,8 +4864,7 @@ class Parser
      * Parses a NamespaceList.
      *
      * $(GRAMMAR $(RULEDEF namespaceList):
-     *       $(RULE ternaryExpression)
-     *     | $(RULE ternaryExpression), $(RULE namespaceList)
+     *     $(RULE ternaryExpression) ($(LITERAL ',') $(RULE ternaryExpression)?)*
      *     ;)
      */
     NamespaceList parseNamespaceList()


### PR DESCRIPTION
Brings this documentation in line with the other list parsing methods.