### PR TITLE
fix memory safety violation / use after free

### DIFF
--- a/src/dparse/lexer.d
+++ b/src/dparse/lexer.d
@@ -538,7 +538,10 @@ public struct DLexer
         this.haveSSE42 = haveSSE42;
         auto r = (range.length >= 3 && range[0] == 0xef && range[1] == 0xbb && range[2] == 0xbf)
             ? range[3 .. $] : range;
-        this.range = LexerRange(cast(const(ubyte)[]) r);
+        static if (is(ElementEncodingType!R == immutable))
+            this.range = LexerRange(cast(const(ubyte)[]) r);
+        else
+            this.range = LexerRange(cast(const(ubyte)[]) r.idup);
         this.config = config;
         this.cache = cache;
         popFront();


### PR DESCRIPTION
before DLexer would take slices from the mutable/const input and just cast(string) them, which violates expectation from the caller that they can modify the memory after the memory finished. This duplicates it on creation of the DLexer struct, fixing corruptions on freed memory or other modifications.

More concretely this fixes a segfault in DCD trying to parse a large module with comments, causing libdparse to call the .comment method in token trivia, which attempts to read the corrupted text content of the comment tokens to check for ddoc. (test file was https://github.com/Pure-D/workspace-d/blob/01f59a101040108c51fae09f7f432876b5e5ec34/source/workspaced/com/dcd.d)

Example of where it was misused: https://github.com/dlang-community/libdparse/blob/0a2ccc066dc00056523a6a4426f8a424112432fb/src/dparse/lexer.d#L1125

The commonly used `getTokensForParser` function overwrites the config comment behavior to noIntern, causing this branch to be called.

I have just duplicated the whole input string instead of duplicating when it's actually sliced because text in nodes is fairly common and would cause memory fragmentation when duplicating on each node. However I did no benchmarking or testing on this to verify which one is better.