### PR TITLE
Support extern(C++ <strings>) with trailing comma

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -3739,7 +3739,7 @@ unittest // issue #398: Support extern(C++, <string expressions...>)
     assert(ns.length == 1);
     checkText(ns[0], `"foo"`);
 
-    ns = getNamespaces(`extern(C++, "foo", "bar", "baz") int i;`);
+    ns = getNamespaces(`extern(C++, "foo", "bar", "baz",) int i;`);
     assert(ns.length == 3);
     checkText(ns[0], `"foo"`);
     checkText(ns[1], `"bar"`);

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4864,13 +4864,13 @@ class Parser
      * Parses a NamespaceList.
      *
      * $(GRAMMAR $(RULEDEF namespaceList):
-     *     $(RULE ternaryExpression) ($(LITERAL ',') $(RULE ternaryExpression)?)*
+     *     $(RULE ternaryExpression) ($(LITERAL ',') $(RULE ternaryExpression)?)* $(LITERAL ',')?
      *     ;)
      */
     NamespaceList parseNamespaceList()
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
-        return parseCommaSeparatedRule!(NamespaceList, TernaryExpression)();
+        return parseCommaSeparatedRule!(NamespaceList, TernaryExpression)(true);
     }
 
     /**


### PR DESCRIPTION
Added with https://issues.dlang.org/show_bug.cgi?id=20791 in DMD 2.093.0

cc @MoonlightSentinel 