### PR TITLE
Fix #428

### DIFF
--- a/src/dparse/astprinter.d
+++ b/src/dparse/astprinter.d
@@ -218,13 +218,13 @@ class XMLPrinter : ASTVisitor
 	{
 		output.writeln("<conditionalDeclaration>");
 		visit(conditionalDeclaration.compileCondition);
-		output.writeln("<trueDeclarations>");
+		output.writeln("<trueDeclarations style=\"", conditionalDeclaration.trueStyle, "\">");
 		foreach (dec; conditionalDeclaration.trueDeclarations)
 			visit(dec);
 		output.writeln("</trueDeclarations>");
 		if (conditionalDeclaration.falseDeclarations.length > 0)
 		{
-			output.writeln("<falseDeclarations>");
+			output.writeln("<falseDeclarations style=\"", conditionalDeclaration.trueStyle, "\">");
 			foreach (dec; conditionalDeclaration.falseDeclarations)
 				visit(dec);
 			output.writeln("</falseDeclarations>");
@@ -1173,7 +1173,7 @@ class XMLPrinter : ASTVisitor
 
 	private void writeName(string name)
 	{
-		output.write("<name>", name, "</name>");
+		output.writeln("<name>", name, "</name>");
 	}
 
 	private void writeDdoc(string comment)

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -1819,8 +1819,9 @@ class Parser
         StackBuffer trueDeclarations;
         if (currentIs(tok!":") || currentIs(tok!"{"))
         {
-            immutable bool brace = advance() == tok!"{";
-            node.trueStyle = currentIs(tok!":") ? DeclarationListStyle.colon : brace ? DeclarationListStyle.block : DeclarationListStyle.single;
+            immutable bool brace = currentIs(tok!"{");
+            node.trueStyle = brace ? DeclarationListStyle.block : DeclarationListStyle.colon;
+            advance();
             while (moreTokens() && !currentIs(tok!"}") && !currentIs(tok!"else"))
             {
                 immutable c = allocator.setCheckpoint();
@@ -1833,8 +1834,12 @@ class Parser
             if (brace)
                 mixin(tokenCheck!"}");
         }
-        else if (!trueDeclarations.put(parseDeclaration(strict, true)))
-            return null;
+        else
+        {
+            if (!trueDeclarations.put(parseDeclaration(strict, true)))
+                return null;
+            node.trueStyle = DeclarationListStyle.single;
+        }
 
         ownArray(node.trueDeclarations, trueDeclarations);
 
@@ -1853,7 +1858,7 @@ class Parser
         if (currentIs(tok!":") || currentIs(tok!"{"))
         {
             immutable bool brace = currentIs(tok!"{");
-            node.falseStyle = currentIs(tok!":") ? DeclarationListStyle.colon : brace ? DeclarationListStyle.block : DeclarationListStyle.single;
+            node.falseStyle = brace ? DeclarationListStyle.block : DeclarationListStyle.colon;
             advance();
             while (moreTokens() && !currentIs(tok!"}"))
                 if (!falseDeclarations.put(parseDeclaration(strict, true)))
@@ -1865,6 +1870,7 @@ class Parser
         {
             if (!falseDeclarations.put(parseDeclaration(strict, true)))
                 return null;
+            node.falseStyle = DeclarationListStyle.single;
         }
         ownArray(node.falseDeclarations, falseDeclarations);
         node.tokens = tokens[startIndex .. index];

--- a/test/ast_checks/issue428.d
+++ b/test/ast_checks/issue428.d
@@ -1,0 +1,2 @@
+debug:
+const a = 1;

--- a/test/ast_checks/issue428.txt
+++ b/test/ast_checks/issue428.txt
@@ -1,0 +1,1 @@
+//conditionalDeclaration//trueDeclarations[@style="colon"]


### PR DESCRIPTION
This fixes a few logic problems in the handling of the `trueStyle` and `falseStyle` fields. The worst of these is that the old code called `advance` to skip over a token before then checking what the token was by looking at the new current token. It also had logic to set the field to `DeclarationListStyle.single` inside of an `if` that checked that there was a `{` or `:`, which makes no sense.