### PR TITLE
Skip the AST checks when the tests are run by Buildkite.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -7,6 +7,7 @@ FAIL_COUNT=0
 NORMAL="\033[01;0m"
 GREEN="\033[32m"
 RED="\033[31m"
+YELLOW="\033[33m"
 DMD=${DMD:=dmd}
 SOURCE_FILES="../src/std/experimental/*.d ../src/dparse/*.d "
 STDX_ALLOC_FILES=$(find ../stdx-allocator/source -name "*.d" )
@@ -48,43 +49,47 @@ else
 	exit 1
 fi
 
-PASS_COUNT=0
-FAIL_COUNT=0
-echo
-for file in ast_checks/*.d; do
-	echo -en "Running AST match tests on ${file}..."
-	# The query file has the same base name as its corresponding D file, but
-	# with a txt extension. It contains XPath expressions, one per line, that
-	# must match nodes in the generated AST.
-	queryFile=ast_checks/$(basename "$file" .d).txt
-	checkCount=1
-	currentPasses=0
-	currentFailures=0
-	while read -r line; do
-		if ./tester --ast "$file" | xmllint --xpath "${line}" - 2>/dev/null > /dev/null; then
-			((currentPasses=currentPasses+1))
+if [[ $BUILDKITE != "true" ]]; then
+	PASS_COUNT=0
+	FAIL_COUNT=0
+	echo
+	for file in ast_checks/*.d; do
+		echo -en "Running AST match tests on ${file}..."
+		# The query file has the same base name as its corresponding D file, but
+		# with a txt extension. It contains XPath expressions, one per line, that
+		# must match nodes in the generated AST.
+		queryFile=ast_checks/$(basename "$file" .d).txt
+		checkCount=1
+		currentPasses=0
+		currentFailures=0
+		while read -r line; do
+			if ./tester --ast "$file" | xmllint --xpath "${line}" - 2>/dev/null > /dev/null; then
+				((currentPasses=currentPasses+1))
+			else
+				echo
+				echo -e "    ${RED}Check on line $checkCount of $queryFile failed.${NORMAL}"
+				((currentFailures=currentFailures+1))
+			fi
+			((checkCount=checkCount+1))
+		done < "$queryFile"
+		if [[ $currentFailures -gt 0 ]]; then
+			echo -e "    ${RED}${currentPasses} check(s) passed and ${currentFailures} check(s) failed${NORMAL}"
+			((FAIL_COUNT=FAIL_COUNT+1))
 		else
-			echo
-			echo -e "    ${RED}Check on line $checkCount of $queryFile failed.${NORMAL}"
-			((currentFailures=currentFailures+1))
+			echo -e " ${GREEN}${currentPasses} check(s) passed and ${currentFailures} check(s) failed${NORMAL}"
+			((PASS_COUNT=PASS_COUNT+1))
 		fi
-		((checkCount=checkCount+1))
-	done < "$queryFile"
-	if [[ $currentFailures -gt 0 ]]; then
-		echo -e "    ${RED}${currentPasses} check(s) passed and ${currentFailures} check(s) failed${NORMAL}"
-		((FAIL_COUNT=FAIL_COUNT+1))
+	done
+	echo
+	if [ "$FAIL_COUNT" -eq 0 ]; then
+		echo -e "${GREEN}${PASS_COUNT} AST test(s) passed and ${FAIL_COUNT} failed.${NORMAL}"
 	else
-		echo -e " ${GREEN}${currentPasses} check(s) passed and ${currentFailures} check(s) failed${NORMAL}"
-		((PASS_COUNT=PASS_COUNT+1))
+		echo -e "${RED}${PASS_COUNT} AST test(s) passed and ${FAIL_COUNT} failed.${NORMAL}"
+		exit 1
 	fi
-done
-
-echo
-if [ "$FAIL_COUNT" -eq 0 ]; then
-	echo -e "${GREEN}${PASS_COUNT} AST test(s) passed and ${FAIL_COUNT} failed.${NORMAL}"
 else
-	echo -e "${RED}${PASS_COUNT} AST test(s) passed and ${FAIL_COUNT} failed.${NORMAL}"
-	exit 1
+	echo
+	echo -e "${YELLOW}Skipping AST checks in Buildkite CI${NORMAL}"
 fi
 
 echo


### PR DESCRIPTION
Fixes #431. 