### PR TITLE
Parse comments after } in function declaration

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -8859,21 +8859,26 @@ protected: final:
             ~ `else {` ~ Exp ~ ` = *t; }}`;
     }
 
+    void attachComment(T)(T node, string comment)
+    {
+        if (comment !is null)
+        {
+            if (node.comment is null)
+                node.comment = comment;
+            else
+            {
+                node.comment ~= "\n";
+                node.comment ~= comment;
+            }
+        }
+    }
+
     T attachCommentFromSemicolon(T)(T node, size_t startIndex)
     {
         auto semicolon = expect(tok!";");
         if (semicolon is null)
             return null;
-        if (semicolon.trailingComment !is null)
-        {
-            if (node.comment is null)
-                node.comment = semicolon.trailingComment;
-            else
-            {
-                node.comment ~= "\n";
-                node.comment ~= semicolon.trailingComment;
-            }
-        }
+        attachComment(node, semicolon.trailingComment);
         if (node) node.tokens = tokens[startIndex .. index];
         return node;
     }

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3520,6 +3520,10 @@ class Parser
             mixin(parseNodeQ!(`node.constraint`, `Constraint`));
 
         mixin(parseNodeQ!(`node.functionBody`, `FunctionBody`));
+        if (node.functionBody &&
+            node.functionBody.specifiedFunctionBody &&
+            node.functionBody.specifiedFunctionBody.blockStatement)
+            attachComment(node, node.functionBody.specifiedFunctionBody.blockStatement.tokens[$ - 1].trailingComment);
         ownArray(node.memberFunctionAttributes, memberFunctionAttributes);
         node.tokens = tokens[startIndex .. index];
         return node;

--- a/test/ast_checks/oneLineFunctionDoc.d
+++ b/test/ast_checks/oneLineFunctionDoc.d
@@ -1,0 +1,1 @@
+void fun() {} /// Test

--- a/test/ast_checks/oneLineFunctionDoc.txt
+++ b/test/ast_checks/oneLineFunctionDoc.txt
@@ -1,0 +1,1 @@
+//functionDeclaration/ddoc


### PR DESCRIPTION
Attempts to fix this DScanner issue:
https://github.com/dlang-community/D-Scanner/issues/499#issuecomment-782807629
