### PR TITLE
Support parsing of shortened function bodies

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -306,6 +306,7 @@ abstract class ASTVisitor
     /** */ void visit(const SharedStaticConstructor sharedStaticConstructor) { sharedStaticConstructor.accept(this); }
     /** */ void visit(const SharedStaticDestructor sharedStaticDestructor) { sharedStaticDestructor.accept(this); }
     /** */ void visit(const ShiftExpression shiftExpression) { shiftExpression.accept(this); }
+    /** */ void visit(const ShortenedFunctionBody shortenedFunctionBody) { shortenedFunctionBody.accept(this); }
     /** */ void visit(const SingleImport singleImport) { singleImport.accept(this); }
     /** */ void visit(const Index index) { index.accept(this); }
     /** */ void visit(const SpecifiedFunctionBody specifiedFunctionBody) { specifiedFunctionBody.accept(this); }
@@ -1713,12 +1714,13 @@ final class FunctionBody : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(specifiedFunctionBody, missingFunctionBody));
+        mixin (visitIfNotNull!(specifiedFunctionBody, missingFunctionBody, shortenedFunctionBody));
     }
 
     /** */ size_t endLocation;
     /** */ SpecifiedFunctionBody specifiedFunctionBody;
     /** */ MissingFunctionBody missingFunctionBody;
+    /** */ ShortenedFunctionBody shortenedFunctionBody;
     mixin OpEquals;
 }
 
@@ -2723,6 +2725,20 @@ final class SpecifiedFunctionBody : BaseNode
     /** */ FunctionContract[] functionContracts;
     /** */ BlockStatement blockStatement;
     /** */ bool hasDo;
+    mixin OpEquals;
+}
+
+///
+final class ShortenedFunctionBody : BaseNode
+{
+    override void accept(ASTVisitor visitor) const
+    {
+        mixin(visitIfNotNull!(expression));
+    }
+
+    /** */ Expression expression;
+    /** */ size_t startLocation;
+    /** */ size_t endLocation;
     mixin OpEquals;
 }
 

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -2737,8 +2737,6 @@ final class ShortenedFunctionBody : BaseNode
     }
 
     /** */ Expression expression;
-    /** */ size_t startLocation;
-    /** */ size_t endLocation;
     mixin OpEquals;
 }
 

--- a/src/dparse/astprinter.d
+++ b/src/dparse/astprinter.d
@@ -1119,6 +1119,7 @@ class XMLPrinter : ASTVisitor
 	override void visit(const ScopeGuardStatement scopeGuardStatement) { mixin (tagAndAccept!"scopeGuardStatement"); }
 	override void visit(const SharedStaticConstructor sharedStaticConstructor) { mixin (tagAndAccept!"sharedStaticConstructor"); }
 	override void visit(const SharedStaticDestructor sharedStaticDestructor) { mixin (tagAndAccept!"sharedStaticDestructor"); }
+	override void visit(const ShortenedFunctionBody shortenedFunctionBody) { mixin (tagAndAccept!"shortenedFunctionBody"); }
 	override void visit(const StatementNoCaseNoDefault statementNoCaseNoDefault) { mixin (tagAndAccept!"statementNoCaseNoDefault"); }
 	override void visit(const StaticAssertDeclaration staticAssertDeclaration) { mixin (tagAndAccept!"staticAssertDeclaration"); }
 	override void visit(const StaticAssertStatement staticAssertStatement) { mixin (tagAndAccept!"staticAssertStatement"); }

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -2653,6 +2653,14 @@ class Formatter(Sink)
         mixin(binary("shiftExpression"));
     }
 
+    void format(const ShortenedFunctionBody shortenedFunctionBody)
+    {
+        debug(verbose) writeln("ShortenedFunctionBody");
+        put("=> ");
+        format(shortenedFunctionBody.expression);
+        put(";");
+    }
+
     void format(const SingleImport singleImport)
     {
         debug(verbose) writeln("SingleImport");

--- a/test/ast_checks/shortenedFunction.d
+++ b/test/ast_checks/shortenedFunction.d
@@ -1,0 +1,1 @@
+int abcdef(int a) => a * 3;

--- a/test/ast_checks/shortenedFunction.txt
+++ b/test/ast_checks/shortenedFunction.txt
@@ -1,0 +1,3 @@
+./module/declaration/functionDeclaration/name[text()="abcdef"]
+./module/declaration/functionDeclaration//functionBody/shortenedFunctionBody
+./module/declaration/functionDeclaration//functionBody/shortenedFunctionBody//mulExpression

--- a/test/pass_files/shortenedMethods.d
+++ b/test/pass_files/shortenedMethods.d
@@ -1,0 +1,3 @@
+// these 2 are equivalent
+int foo() { return 1; }
+int bar() => 1;


### PR DESCRIPTION
Support for 2.096.0's new `-preview=shortenedMethods` syntax.