### PR TITLE
Update stdx-allocator.wrap

### DIFF
--- a/subprojects/stdx-allocator.wrap
+++ b/subprojects/stdx-allocator.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = stdx-allocator
 url       = https://github.com/dlang-community/stdx-allocator.git
-revision  = v2.77.5
+revision  = HEAD


### PR DESCRIPTION
if this works this is not the end of the problems, mir-core will have to be added to dcd, d-scanner etc. as a dependency.