### PR TITLE
Implement `ThrowExpression`'s proposed by DIP 1034

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -344,7 +344,7 @@ abstract class ASTVisitor
     /** */ void visit(const TemplateValueParameter templateValueParameter) { templateValueParameter.accept(this); }
     /** */ void visit(const TemplateValueParameterDefault templateValueParameterDefault) { templateValueParameterDefault.accept(this); }
     /** */ void visit(const TernaryExpression ternaryExpression) { ternaryExpression.accept(this); }
-    /** */ void visit(const ThrowStatement throwStatement) { throwStatement.accept(this); }
+    /** */ void visit(const ThrowExpression throwExpression) { throwExpression.accept(this); }
     /** */ void visit(const Token) { }
     /** */ void visit(const TraitsExpression traitsExpression) { traitsExpression.accept(this); }
     /** */ void visit(const TryStatement tryStatement) { tryStatement.accept(this); }
@@ -2376,7 +2376,7 @@ final class StatementNoCaseNoDefault : BaseNode
             whileStatement, doStatement, forStatement, foreachStatement,
             switchStatement, finalSwitchStatement, continueStatement,
             breakStatement, returnStatement, gotoStatement, withStatement,
-            synchronizedStatement, tryStatement, throwStatement,
+            synchronizedStatement, tryStatement,
             scopeGuardStatement, asmStatement, pragmaStatement,
             conditionalStatement, staticAssertStatement, versionSpecification,
             debugSpecification, expressionStatement, staticForeachStatement));
@@ -2398,7 +2398,6 @@ final class StatementNoCaseNoDefault : BaseNode
     /** */ WithStatement withStatement;
     /** */ SynchronizedStatement synchronizedStatement;
     /** */ TryStatement tryStatement;
-    /** */ ThrowStatement throwStatement;
     /** */ ScopeGuardStatement scopeGuardStatement;
     /** */ AsmStatement asmStatement;
     /** */ PragmaStatement pragmaStatement;
@@ -3187,14 +3186,18 @@ final class TernaryExpression : ExpressionNode
     mixin OpEquals;
 }
 
+deprecated("Replaced by ExpressionStatement + ThrowExpression")
+alias ThrowStatement = ThrowExpression;
+
 ///
-final class ThrowStatement : BaseNode
+final class ThrowExpression: ExpressionNode
 {
     override void accept(ASTVisitor visitor) const
     {
         mixin (visitIfNotNull!(expression));
     }
-    /** */ Expression expression;
+
+    /** */ ExpressionNode expression;
     mixin OpEquals;
 }
 
@@ -3322,7 +3325,8 @@ final class UnaryExpression : ExpressionNode
         // TODO prefix, postfix, unary
         mixin (visitIfNotNull!(primaryExpression, newExpression, deleteExpression,
             castExpression, functionCallExpression, argumentList, unaryExpression,
-            type, identifierOrTemplateInstance, assertExpression, indexExpression));
+            type, identifierOrTemplateInstance, assertExpression, throwExpression,
+            indexExpression));
     }
 
     /** */ Type type;
@@ -3337,6 +3341,7 @@ final class UnaryExpression : ExpressionNode
     /** */ ArgumentList argumentList;
     /** */ IdentifierOrTemplateInstance identifierOrTemplateInstance;
     /** */ AssertExpression assertExpression;
+    /** */ ThrowExpression throwExpression;
     /** */ IndexExpression indexExpression;
     /** */ size_t dotLocation;
     mixin OpEquals;
@@ -3953,4 +3958,3 @@ unittest // Support GCC-sytle asm statements
         }
     });
 }
-

--- a/src/dparse/astprinter.d
+++ b/src/dparse/astprinter.d
@@ -1148,7 +1148,7 @@ class XMLPrinter : ASTVisitor
 	override void visit(const TemplateValueParameter templateValueParameter) { mixin (tagAndAccept!"templateValueParameter"); }
 	override void visit(const TernaryExpression ternaryExpression) { mixin (tagAndAccept!"ternaryExpression"); }
 	override void visit(const TypeIdentifierPart typeIdentifierPart) { mixin (tagAndAccept!"typeIdentifierPart"); }
-	override void visit(const ThrowStatement throwStatement) { mixin (tagAndAccept!"throwStatement"); }
+	override void visit(const ThrowExpression throwExpression) { mixin (tagAndAccept!"throwExpression"); }
 	override void visit(const TryStatement tryStatement) { mixin (tagAndAccept!"tryStatement"); } override void visit(const TemplateInstance templateInstance) { mixin (tagAndAccept!"templateInstance"); }
 	override void visit(const TypeofExpression typeofExpression) { mixin (tagAndAccept!"typeofExpression"); } override void visit(const TypeSpecialization typeSpecialization) { mixin (tagAndAccept!"typeSpecialization"); } override void visit(const TraitsExpression traitsExpression) { mixin (tagAndAccept!"traitsExpression"); }
 	override void visit(const Vector vector) { mixin (tagAndAccept!"vector"); }

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -2741,7 +2741,6 @@ class Formatter(Sink)
                 "withStatement",
                 "synchronizedStatement",
                 "tryStatement",
-                "throwStatement",
                 "scopeGuardStatement",
                 "asmStatement",
                 "conditionalStatement",
@@ -3297,14 +3296,13 @@ class Formatter(Sink)
         }
     }
 
-    void format(const ThrowStatement throwStatement)
+    void format(const ThrowExpression throwExpression)
     {
-        debug(verbose) writeln("ThrowStatement");
+        debug(verbose) writeln("ThrowExpression");
 
         put("throw ");
-        assert(throwStatement.expression);
-        format(throwStatement.expression);
-        put(";");
+        assert(throwExpression.expression);
+        format(throwExpression.expression);
     }
 
     void format(const Token token)
@@ -3593,6 +3591,7 @@ class Formatter(Sink)
             if (castExpression) format(castExpression);
             if (functionCallExpression) format(functionCallExpression);
             if (assertExpression) format(assertExpression);
+            if (throwExpression) format(throwExpression);
             if (indexExpression) format(indexExpression);
 
             if (unaryExpression) format(unaryExpression);
@@ -4247,4 +4246,10 @@ do
     int i;
 }`
 );
+    testFormatNode!(Declaration)(q{int i = throw new Ex();});
+    testFormatNode!(FunctionDeclaration)(q{void someFunction()
+{
+    foo(a, throw b, c);
+    return throw new Exception("", "");
+}});
 }

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -6001,7 +6001,6 @@ class Parser
      *     | $(RULE withStatement)
      *     | $(RULE synchronizedStatement)
      *     | $(RULE tryStatement)
-     *     | $(RULE throwStatement)
      *     | $(RULE scopeGuardStatement)
      *     | $(RULE pragmaStatement)
      *     | $(RULE asmStatement)
@@ -6064,9 +6063,6 @@ class Parser
             break;
         case tok!"try":
             mixin(parseNodeQ!(`node.tryStatement`, `TryStatement`));
-            break;
-        case tok!"throw":
-            mixin(parseNodeQ!(`node.throwStatement`, `ThrowStatement`));
             break;
         case tok!"scope":
             mixin(parseNodeQ!(`node.scopeGuardStatement`, `ScopeGuardStatement`));
@@ -7061,20 +7057,19 @@ class Parser
     }
 
     /**
-     * Parses a ThrowStatement
+     * Parses a ThrowExpression
      *
-     * $(GRAMMAR $(RULEDEF throwStatement):
-     *     $(LITERAL 'throw') $(RULE expression) $(LITERAL ';')
+     * $(GRAMMAR $(RULEDEF throwExpression):
+     *     $(LITERAL 'throw') $(RULE assignExpression)
      *     ;)
      */
-    ThrowStatement parseThrowStatement()
+    ThrowExpression parseThrowExpression()
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto startIndex = index;
-        auto node = allocator.make!ThrowStatement;
+        auto node = allocator.make!ThrowExpression;
         expect(tok!"throw");
-        mixin(parseNodeQ!(`node.expression`, `Expression`));
-        expect(tok!";");
+        mixin(parseNodeQ!(`node.expression`, `AssignExpression`));
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -7526,6 +7521,7 @@ class Parser
      *     | $(RULE deleteExpression)
      *     | $(RULE castExpression)
      *     | $(RULE assertExpression)
+     *     | $(RULE throwExpression)
      *     | $(RULE functionCallExpression)
      *     | $(RULE indexExpression)
      *     | $(LITERAL '$(LPAREN)') $(RULE type) $(LITERAL '$(RPAREN)') $(LITERAL '.') $(RULE identifierOrTemplateInstance)
@@ -7588,6 +7584,9 @@ class Parser
             break;
         case tok!"assert":
             mixin(parseNodeQ!(`node.assertExpression`, `AssertExpression`));
+            break;
+        case tok!"throw":
+            mixin(parseNodeQ!(`node.throwExpression`, `ThrowExpression`));
             break;
         case tok!"(":
             // handle (type).identifier

--- a/test/ast_checks/throw_expressions.d
+++ b/test/ast_checks/throw_expressions.d
@@ -1,0 +1,6 @@
+int main()
+{
+    foo(throw someThrowable, bar);
+
+    return foo ? bar : throw new Exception("Hello, World!");
+}

--- a/test/ast_checks/throw_expressions.txt
+++ b/test/ast_checks/throw_expressions.txt
@@ -1,0 +1,8 @@
+//functionDeclaration[name = 'main']
+//functionCallExpression/unaryExpression/primaryExpression/identifierOrTemplateInstance[identifier='foo']
+//functionCallExpression/arguments/argumentList/unaryExpression[1]/throwExpression//*[identifier='someThrowable']
+//functionCallExpression/arguments/argumentList/unaryExpression[2]/primaryExpression/*[identifier='bar']
+//ternaryExpression/*[1]//*[identifier='foo']
+//ternaryExpression/*[2]//*[identifier='bar']
+//ternaryExpression/*[3]/throwExpression/unaryExpression/newExpression/type[@pretty='Exception']
+//ternaryExpression/*[3]/throwExpression/unaryExpression/newExpression/arguments//stringLiteral


### PR DESCRIPTION
`ThrowExpression`'s replace `ThrowStatement`'s which may appear nested into any other declaration.

- dlang/dmd#13162
- dlang/dlang.org#3164
