### PR TITLE
allow in/out contract expressions in shortened methods

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -2747,9 +2747,10 @@ final class ShortenedFunctionBody : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin(visitIfNotNull!(expression));
+        mixin(visitIfNotNull!(functionContracts, expression));
     }
 
+    /** */ FunctionContract[] functionContracts;
     /** */ Expression expression;
     mixin OpEquals;
 }

--- a/test/ast_checks/shortenedFunction.d
+++ b/test/ast_checks/shortenedFunction.d
@@ -1,1 +1,2 @@
 int abcdef(int a) => a * 3;
+@property propy() in(true || false) out(r; r == 4) => _x;

--- a/test/ast_checks/shortenedFunction.txt
+++ b/test/ast_checks/shortenedFunction.txt
@@ -1,3 +1,8 @@
-./module/declaration/functionDeclaration/name[text()="abcdef"]
-./module/declaration/functionDeclaration//functionBody/shortenedFunctionBody
-./module/declaration/functionDeclaration//functionBody/shortenedFunctionBody//mulExpression
+./module/declaration[1]/functionDeclaration/name[text()="abcdef"]
+./module/declaration[1]/functionDeclaration//functionBody/shortenedFunctionBody
+./module/declaration[1]/functionDeclaration//functionBody/shortenedFunctionBody//mulExpression
+./module/declaration[2]/functionDeclaration/name[text()="propy"]
+./module/declaration[2]/functionDeclaration/storageClass/atAttribute/identifier[text()="property"]
+./module/declaration[2]/functionDeclaration//functionBody/shortenedFunctionBody
+./module/declaration[2]/functionDeclaration//inOutContractExpression[1]//inContractExpression
+./module/declaration[2]/functionDeclaration//inOutContractExpression[2]//outContractExpression

--- a/test/fail_files/shortenedMethod.d
+++ b/test/fail_files/shortenedMethod.d
@@ -1,0 +1,1 @@
+int bar() in { assert(true); } => 1;

--- a/test/pass_files/shortenedMethods.d
+++ b/test/pass_files/shortenedMethods.d
@@ -1,3 +1,37 @@
 // these 2 are equivalent
 int foo() { return 1; }
 int bar() => 1;
+
+// https://github.com/dlang/dmd/blob/52844d4b1e9d6714bfd2e535f25a72074a046209/test/compilable/shortened_methods.d
+class A {
+    int _x = 34;
+    // short syntax works in all contexts
+    @property x() => _x;
+    @property x(int v) => _x = v;
+
+    // including with contracts
+    @property y() in(true) => _x;
+
+    // or other auto returns
+    auto foo() @safe => assert(0);
+
+    // or normal method defintions
+    bool isNull() => this is null;
+}
+
+class B : A{
+    // short syntax also overrides the same as long syntax
+    override bool isNull() => this !is null;
+}
+
+static assert((new A).x == 34);
+
+string test() => "hello"; // works at any scope
+
+static assert(test() == "hello"); // works normally
+static assert(is(typeof(&test) == string function())); // same normal type
+
+void func() {
+    int a;
+    int nested() => a; // and at nested scopes too
+}


### PR DESCRIPTION
Fixes contract expressions with shortened methods introduced in the previous PR #439 

Might want to improve syntax errors with it, but this should work for now.