### PR TITLE
add same-line docs to aggregate types & templates

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -6422,6 +6422,7 @@ class Parser
         if (currentIs(tok!"{"))
         {
             mixin(parseNodeQ!(`node.structBody`, `StructBody`));
+            attachComment(node, node.structBody.tokens[$ - 1].trailingComment);
         }
         else if (currentIs(tok!";"))
             advance();
@@ -6758,7 +6759,11 @@ class Parser
         }
         ownArray(node.declarations, declarations);
         const end = expect(tok!"}");
-        if (end !is null) node.endLocation = end.index;
+        if (end !is null)
+        {
+            node.endLocation = end.index;
+            attachComment(node, end.trailingComment);
+        }
         node.tokens = tokens[startIndex .. index];
         return node;
     }
@@ -7762,9 +7767,14 @@ class Parser
             node.name.column = t.column;
     semiOrStructBody:
             if (currentIs(tok!";"))
+            {
                 advance();
+            }
             else
+            {
                 mixin(parseNodeQ!(`node.structBody`, `StructBody`));
+                attachComment(node, node.structBody.tokens[$ - 1].trailingComment);
+            }
         }
         node.tokens = tokens[startIndex .. index];
         return node;
@@ -9047,6 +9057,7 @@ protected: final:
         }
     structBody:
         mixin(parseNodeQ!(`node.structBody`, `StructBody`));
+        attachComment(node, node.structBody.tokens[$ - 1].trailingComment);
         node.tokens = tokens[startIndex .. index];
         return node;
     emptyBody:


### PR DESCRIPTION
Now code like `class X {} /// foo` properly gets documentation, like in the `dmd -D` output.

Extends #438 

This code in D-Scanner now properly gets recognized as documented:
```
class C{} /// a
interface I{} /// b
enum e = 0; /// c
void f(){} /// d
struct S{} /// e
template T(){} /// f
union U{} /// g
```

This will fully fix https://github.com/dlang-community/D-Scanner/issues/499