### PR TITLE
Fix #484, support multiple message parts in assert

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -874,11 +874,21 @@ final class AssertArguments : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(assertion, message));
+        mixin (visitIfNotNull!(assertion, messageParts));
     }
+
     /** */ ExpressionNode assertion;
-    /** */ ExpressionNode message;
+    /** */ ExpressionNode[] messageParts;
     mixin OpEquals;
+
+    deprecated("use firstMessage or process all messageParts instead")
+    alias message = firstMessage;
+
+    /// Returns `messageParts[0]` or `null` if no messageParts.
+    inout(ExpressionNode) firstMessage() inout nothrow pure @nogc @safe
+    {
+        return messageParts.length ? messageParts[0] : null;
+    }
 }
 
 ///

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -406,18 +406,13 @@ class Formatter(Sink)
     {
         debug(verbose) writeln("AssertExpression");
 
-        /**
-        AssignExpression assertion;
-        AssignExpression message;
-        **/
-
         with(assertArguments)
         {
             format(assertion);
-            if (message)
+            foreach (part; messageParts)
             {
                 put(", ");
-                format(message);
+                format(part);
             }
         }
     }

--- a/test/ast_checks/assert_args.d
+++ b/test/ast_checks/assert_args.d
@@ -1,0 +1,1 @@
+static assert(foo, "a", b, "c");

--- a/test/ast_checks/assert_args.txt
+++ b/test/ast_checks/assert_args.txt
@@ -1,0 +1,4 @@
+./module/declaration/staticAssertDeclaration//assertArguments/unaryExpression[1]//identifierOrTemplateInstance/identifier[text()="foo"]
+./module/declaration/staticAssertDeclaration//assertArguments/unaryExpression[2]/primaryExpression/stringLiteral[text()='"a"']
+./module/declaration/staticAssertDeclaration//assertArguments/unaryExpression[3]//identifierOrTemplateInstance/identifier[text()="b"]
+./module/declaration/staticAssertDeclaration//assertArguments/unaryExpression[4]/primaryExpression/stringLiteral[text()='"c"']


### PR DESCRIPTION
Also modified the AST for regular asserts, for future proofing and easier implementation.

cc @RazvanN7

Introduces a deprecation in opEquals, it's fixed in #485 