### PR TITLE
syntax changes from 2.104.0

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -993,7 +993,8 @@ final class AssocArrayLiteral : BaseNode
     mixin OpEquals;
 }
 
-///
+/// User-defined `@attribute` attributes. Also includes `@disable`, `@nogc`,
+/// `@live`, etc. by simply having them be regular identifiers.
 final class AtAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -1000,13 +1000,46 @@ final class AtAttribute : BaseNode
     {
         mixin (visitIfNotNull!(templateInstance, argumentList));
     }
-    /** */ ArgumentList argumentList;
-    /** */ TemplateInstance templateInstance;
-    /** */ Token identifier;
-    /** */ bool useParen;
+
+    /// Set for all of `@identifier(argumentList)`,
+    /// `@templateInstance!T(argumentList)` and `@(argumentListInParens)`.
+    ArgumentList argumentList;
+    /// When there is at least one template argument (`@id!T` or `@id!(T, U)`,
+    /// etc.), this is set instead of $(LREF identifier).
+    /// For regular `@identifier` or `@fn(args)` UDAs without template arguments,
+    /// `identifier` is set instead.
+    TemplateInstance templateInstance;
+    /// True for `@(argumentList)` code, as well as
+    /// `@templateInstance!T(argumentList)` and `@identifier(argumentList)`.
+    bool useParen;
+    /// For `@identifier`, the identifier part.
+    /// Not set for `@identifer!templateArgs`, see $(LREF templateInstance) for that.
+    /// This is however set for `@identifier(regularArguments)`.
+    Token identifier;
+    /// For `@int` or `@5`, the part after the `@`. May only be a single token,
+    /// may not be identifier (see $(LREF identifier) for that).
+    /// Introduced with DMD 2.104.0
+    TemplateSingleArgument templateSingleArgument;
+
     /** */ size_t startLocation;
     /** */ size_t endLocation;
     mixin OpEquals;
+
+    /// Returns either $(LREF identifier) or $(LREF templateSingleArgument),
+    /// whichever is set, otherwise `Token.init`.
+    ///
+    /// This is the single token after the `@` for `@identifier`, `@5`,
+    /// `@"string literal"`, etc.
+    ///
+    /// Not set if parens are used, e.g. not set for `@("string in parens")`.
+    Token token() const nothrow pure @nogc @safe scope
+    {
+        return identifier != tok!""
+            ? identifier
+            : templateSingleArgument
+                ? templateSingleArgument.token
+                : Token.init;
+    }
 }
 
 ///

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -998,7 +998,7 @@ final class AtAttribute : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(templateInstance, argumentList));
+        mixin (visitIfNotNull!(templateInstance, argumentList, templateSingleArgument));
     }
 
     /// Set for all of `@identifier(argumentList)`,

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -504,8 +504,13 @@ class Formatter(Sink)
         with(atAttribute)
         {
             put("@");
-            format(identifier);
+            format(token);
+            if (templateInstance) format(templateInstance);
+            if (useParen)
+                put("(");
             if(argumentList) format(argumentList);
+            if (useParen)
+                put(")");
         }
     }
 
@@ -4310,6 +4315,14 @@ do
     foo(a, throw b, c);
     return throw new Exception("", "");
 }});
+    testFormatNode!(Declaration)(q{@true long x;});
+    testFormatNode!(Declaration)(q{@(true) long x;});
+    testFormatNode!(Declaration)(q{@f(true) long x;});
+    testFormatNode!(Declaration)(q{@f long x;});
+    testFormatNode!(Declaration)(q{@f() long x;});
+    testFormatNode!(Declaration)(q{@f!T(true) long x;});
+    testFormatNode!(Declaration)(q{@f!T long x;});
+    testFormatNode!(Declaration)(q{@(f!T) long x;});
 
     testFormatNode!(IfCondition)(q{void foo()
 {

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -1227,6 +1227,7 @@ class Parser
      *     | $(LITERAL '@') $(LITERAL Identifier) $(LITERAL '$(LPAREN)') $(RULE argumentList)? $(LITERAL '$(RPAREN)')
      *     | $(LITERAL '@') $(LITERAL '$(LPAREN)') $(RULE argumentList) $(LITERAL '$(RPAREN)')
      *     | $(LITERAL '@') $(RULE templateInstance)
+     *     | $(LITERAL '@') $(RULE templateSingleArgument)
      *     ;)
      */
     AtAttribute parseAtAttribute()
@@ -1238,7 +1239,7 @@ class Parser
         mixin (nullCheck!`start`);
         if (!moreTokens)
         {
-            error("`(`, or identifier expected");
+            error("`(`, identifier or single template argument expected");
             return null;
         }
         node.startLocation = start.index;
@@ -1265,8 +1266,8 @@ class Parser
             expect(tok!")");
             break;
         default:
-            error("`(`, or identifier expected");
-            return null;
+            mixin(parseNodeQ!(`node.templateSingleArgument`, `TemplateSingleArgument`));
+            break;
         }
         if (moreTokens) node.endLocation = current().index;
         node.tokens = tokens[startIndex .. index];

--- a/test/pass_files/compiler_2_104_0.d
+++ b/test/pass_files/compiler_2_104_0.d
@@ -1,0 +1,6 @@
+@int void f();
+
+@"my test" unittest
+{
+
+}


### PR DESCRIPTION
supports for example `@true` or `@int` now