### PR TITLE
interpolated strings, v2

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -16,10 +16,10 @@
 module dparse.ast;
 
 import dparse.lexer;
-import std.traits;
 import std.algorithm;
 import std.array;
 import std.string;
+import std.traits;
 
 private immutable uint[TypeInfo] typeMap;
 
@@ -1425,8 +1425,8 @@ final class Declaration : BaseNode
         }
     }
 
-    private import std.variant:Algebraic;
-    private import std.typetuple:TypeTuple;
+    import std.typetuple : TypeTuple;
+    import std.variant : Algebraic;
 
     alias DeclarationTypes = TypeTuple!(AliasDeclaration, AliasAssign, AliasThisDeclaration,
         AnonymousEnumDeclaration, AttributeDeclaration,
@@ -3483,9 +3483,10 @@ final class TemplateSingleArgument : BaseNode
 {
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(token));
+        mixin (visitIfNotNull!(token, istring));
     }
     /** */ Token token;
+    /** */ InterpolatedString istring;
     mixin OpEquals;
 }
 
@@ -4092,7 +4093,7 @@ unittest //#365 : used to segfault
 unittest // issue #398: Support extern(C++, <string expressions...>)
 {
     import dparse.lexer : LexerConfig;
-    import dparse.parser : ParserConfig, parseModule;
+    import dparse.parser : parseModule, ParserConfig;
     import dparse.rollback_allocator : RollbackAllocator;
 
     RollbackAllocator ra;

--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -75,7 +75,6 @@ shared static this()
     typeMap[typeid(XorExpression)] = 48;
     typeMap[typeid(InterpolatedStringExpression)] = 49;
     typeMap[typeid(InterpolatedStringText)] = 50;
-    typeMap[typeid(InterpolatedStringVariable)] = 51;
 }
 
 /// Describes which syntax was used in a list of declarations in the containing AST node
@@ -170,7 +169,7 @@ abstract class ASTVisitor
         case 46: visit(cast(TypeofExpression) n); break;
         case 47: visit(cast(UnaryExpression) n); break;
         case 48: visit(cast(XorExpression) n); break;
-        // skip 49, 50, 51 (used for InterpolatedStringPart)
+        // skip 49, 50 (used for InterpolatedStringPart)
         default: assert(false, __MODULE__ ~ " has a bug");
         }
     }
@@ -182,7 +181,6 @@ abstract class ASTVisitor
         {
         case 49: visit(cast(InterpolatedStringExpression) n); break;
         case 50: visit(cast(InterpolatedStringText) n); break;
-        case 51: visit(cast(InterpolatedStringVariable) n); break;
         default: assert(false, __MODULE__ ~ " has a bug");
         }
     }
@@ -308,7 +306,6 @@ abstract class ASTVisitor
     /** */ void visit(const InterpolatedString interpolatedString) { interpolatedString.accept(this); }
     /** */ void visit(const InterpolatedStringExpression interpolatedStringExpression) { interpolatedStringExpression.accept(this); }
     /** */ void visit(const InterpolatedStringText interpolatedStringText) { interpolatedStringText.accept(this); }
-    /** */ void visit(const InterpolatedStringVariable interpolatedStringVariable) { interpolatedStringVariable.accept(this); }
     /** */ void visit(const Invariant invariant_) { invariant_.accept(this); }
     /** */ void visit(const IsExpression isExpression) { isExpression.accept(this); }
     /** */ void visit(const KeyValuePair keyValuePair) { keyValuePair.accept(this); }
@@ -2382,12 +2379,12 @@ final class InterpolatedString : BaseNode
     mixin OpEquals!("startQuote.text", "postfixType");
 }
 
-///
+/// AST nodes within an interpolated string
 abstract class InterpolatedStringPart : BaseNode
 {
 }
 
-///
+/// Just plain text inside the interpolated string
 final class InterpolatedStringText : InterpolatedStringPart
 {
     override void accept(ASTVisitor visitor) const
@@ -2403,29 +2400,7 @@ final class InterpolatedStringText : InterpolatedStringPart
     mixin OpEquals!("text.text");
 }
 
-///
-final class InterpolatedStringVariable : InterpolatedStringPart
-{
-    override void accept(ASTVisitor visitor) const
-    {
-    }
-
-    /// The dollar token.
-    inout(Token) dollar() inout pure nothrow @nogc @safe scope
-    {
-        return tokens.length == 2 ? tokens[0] : Token.init;
-    }
-
-    /// The variable name token.
-    inout(Token) name() inout pure nothrow @nogc @safe scope
-    {
-        return tokens.length == 2 ? tokens[1] : Token.init;
-    }
-
-    mixin OpEquals!("name.text");
-}
-
-///
+/// A $(...) interpolation sequence
 final class InterpolatedStringExpression : InterpolatedStringPart
 {
     override void accept(ASTVisitor visitor) const

--- a/src/dparse/astprinter.d
+++ b/src/dparse/astprinter.d
@@ -599,11 +599,6 @@ class XMLPrinter : ASTVisitor
 		output.writeln("<text>", xmlEscape(interpolatedStringText.text.text), "</text>");
 	}
 
-	override void visit(const InterpolatedStringVariable interpolatedStringVariable)
-	{
-		output.writeln("<variable>", xmlEscape(interpolatedStringVariable.name.text), "</variable>");
-	}
-
 	override void visit(const InterpolatedStringExpression interpolatedStringExpression)
 	{
 		visit(interpolatedStringExpression.expression);

--- a/src/dparse/astprinter.d
+++ b/src/dparse/astprinter.d
@@ -582,6 +582,33 @@ class XMLPrinter : ASTVisitor
 		output.writeln("</interfaceDeclaration>");
 	}
 
+	override void visit(const InterpolatedString interpolatedString)
+	{
+		output.writeln("<interpolatedString startQuote=\"",
+			xmlAttributeEscape(interpolatedString.startQuote.text),
+			"\" endQuote=\"",
+			xmlAttributeEscape(interpolatedString.endQuote.text),
+			"\">");
+		foreach (part; interpolatedString.parts)
+			dynamicDispatch(part);
+		output.writeln("</interpolatedString>");
+	}
+
+	override void visit(const InterpolatedStringText interpolatedStringText)
+	{
+		output.writeln("<text>", xmlEscape(interpolatedStringText.text.text), "</text>");
+	}
+
+	override void visit(const InterpolatedStringVariable interpolatedStringVariable)
+	{
+		output.writeln("<variable>", xmlEscape(interpolatedStringVariable.name.text), "</variable>");
+	}
+
+	override void visit(const InterpolatedStringExpression interpolatedStringExpression)
+	{
+		visit(interpolatedStringExpression.expression);
+	}
+
 	override void visit(const Invariant invariant_)
 	{
 		output.writeln("<invariant>");

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -3290,7 +3290,10 @@ class Formatter(Sink)
         **/
 
         put("!");
-        format(templateSingleArgument.token);
+        if (templateSingleArgument.istring)
+            format(templateSingleArgument.istring);
+        else
+            format(templateSingleArgument.token);
     }
 
     void format(const TemplateThisParameter templateThisParameter)
@@ -4405,5 +4408,10 @@ z /// Documentation for z
     testFormatNode!(VariableDeclaration)(`T x = i" hello $(name) ";`);
     testFormatNode!(VariableDeclaration)(`T x = i" hello $( name ) ";`, `T x = i" hello $(name) ";`);
     testFormatNode!(VariableDeclaration)(`auto a = iq{ "}" hi };`, `auto a = iq{ "}" hi };`);
-    testFormatNode!(VariableDeclaration)("T x = iq{\n};", "T x = iq{\n};");
+    testFormatNode!(VariableDeclaration)("T x = iq{\n};");
+    testFormatNode!(AliasDeclaration)(`alias expr = AliasSeq!i"$(a) $(b)";`);
+    testFormatNode!(VariableDeclaration)(q{auto thing = i"$(b) $("$" ~ ')' ~ `"`)";});
+    testFormatNode!(VariableDeclaration)("auto x = i` $(b) is $(b)!`;");
+    testFormatNode!(VariableDeclaration)("auto x = iq{ $(b) is $(b)!};");
+    testFormatNode!(VariableDeclaration)("auto x = iq{{$('$')}};");
 }

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -4410,7 +4410,7 @@ z /// Documentation for z
     testFormatNode!(VariableDeclaration)(`auto a = iq{ "}" hi };`, `auto a = iq{ "}" hi };`);
     testFormatNode!(VariableDeclaration)("T x = iq{\n};");
     testFormatNode!(AliasDeclaration)(`alias expr = AliasSeq!i"$(a) $(b)";`);
-    testFormatNode!(VariableDeclaration)(q{auto thing = i"$(b) $("$" ~ ')' ~ `"`)";});
+    testFormatNode!(VariableDeclaration)("auto thing = i\"$(b) $(\"$\" ~ ')' ~ `\"`)\";");
     testFormatNode!(VariableDeclaration)("auto x = i` $(b) is $(b)!`;");
     testFormatNode!(VariableDeclaration)("auto x = iq{ $(b) is $(b)!};");
     testFormatNode!(VariableDeclaration)("auto x = iq{{$('$')}};");

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -2019,7 +2019,6 @@ class Formatter(Sink)
         foreach (part; interpolatedString.parts)
         {
             if (cast(InterpolatedStringText) part) format(cast(InterpolatedStringText) part);
-            else if (cast(InterpolatedStringVariable) part) format(cast(InterpolatedStringVariable) part);
             else if (cast(InterpolatedStringExpression) part) format(cast(InterpolatedStringExpression) part);
         }
         put(interpolatedString.endQuote.text);
@@ -2028,12 +2027,6 @@ class Formatter(Sink)
     void format(const InterpolatedStringText interpolatedStringText)
     {
         put(interpolatedStringText.text.text);
-    }
-
-    void format(const InterpolatedStringVariable interpolatedStringVariable)
-    {
-        put("$");
-        put(interpolatedStringVariable.name.text);
     }
 
     void format(const InterpolatedStringExpression interpolatedStringExpression)

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4674,13 +4674,7 @@ class Parser
         }
         else if (currentIs(tok!"$"))
         {
-            if (peekIs(tok!"identifier"))
-            {
-                node = allocator.make!InterpolatedStringVariable;
-                advance();
-                advance();
-            }
-            else if (peekIs(tok!"("))
+            if (peekIs(tok!"("))
             {
                 advance();
                 advance();

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -7254,6 +7254,7 @@ class Parser
      *     | $(LITERAL StringLiteral)
      *     | $(LITERAL IntegerLiteral)
      *     | $(LITERAL FloatLiteral)
+     *     | $(LITERAL InterpolatedString)
      *     | $(LITERAL '_true')
      *     | $(LITERAL '_false')
      *     | $(LITERAL '_null')
@@ -7288,6 +7289,9 @@ class Parser
         foreach (B; Literals) { case B: }
         foreach (C; BasicTypes) { case C: }
             node.token = advance();
+            break;
+        case tok!"istringLiteralStart":
+            node.istring = parseInterpolatedString();
             break;
         default:
             error(`Invalid template argument. (Try enclosing in parenthesis?)`);

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -2,15 +2,15 @@
 
 module dparse.parser;
 
-import dparse.lexer;
 import dparse.ast;
+import dparse.lexer;
 import dparse.rollback_allocator;
 import dparse.stack_buffer;
-import std.experimental.allocator.mallocator;
-import std.experimental.allocator;
-import std.conv;
 import std.algorithm;
 import std.array;
+import std.conv;
+import std.experimental.allocator;
+import std.experimental.allocator.mallocator;
 import std.string : format;
 
 // Uncomment this if you want ALL THE OUTPUT
@@ -4635,8 +4635,13 @@ class Parser
         {
             if (auto c = parseInterpolatedStringPart())
                 parts.put(c);
-            else
+            else if (moreTokens)
                 advance();
+            else
+            {
+                error("Expected more interpolated string parts but got EOF ", false);
+                return null;
+            }
         }
         ownArray(node.parts, parts);
         expect(tok!"istringLiteralEnd");

--- a/test/ast_checks/interpolated_string.d
+++ b/test/ast_checks/interpolated_string.d
@@ -1,0 +1,4 @@
+void foo()
+{
+	writeln(i"Hello $name, you have $$(wealth) in your account right now");
+}

--- a/test/ast_checks/interpolated_string.d
+++ b/test/ast_checks/interpolated_string.d
@@ -1,4 +1,4 @@
 void foo()
 {
-	writeln(i"Hello $name, you have $$(wealth) in your account right now");
+	writeln(i"Hello name, you have $$(wealth) in your account right now");
 }

--- a/test/ast_checks/interpolated_string.txt
+++ b/test/ast_checks/interpolated_string.txt
@@ -1,0 +1,7 @@
+//interpolatedString[@startQuote='i"']
+//interpolatedString[@endQuote='"']
+//interpolatedString/text[text()='Hello ']
+//interpolatedString/text[text()=', you have $']
+//interpolatedString/text[text()=' in your account right now']
+//interpolatedString/variable[text()='name']
+//interpolatedString/expression/unaryExpression

--- a/test/ast_checks/interpolated_string.txt
+++ b/test/ast_checks/interpolated_string.txt
@@ -1,7 +1,5 @@
 //interpolatedString[@startQuote='i"']
 //interpolatedString[@endQuote='"']
-//interpolatedString/text[text()='Hello ']
-//interpolatedString/text[text()=', you have $']
+//interpolatedString/text[text()='Hello name, you have $']
 //interpolatedString/text[text()=' in your account right now']
-//interpolatedString/variable[text()='name']
 //interpolatedString/expression/unaryExpression

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -88,12 +88,12 @@ if [[ ${BUILDKITE:-} != "true" ]]; then
 				expectParseFailure=1
 			elif [[ "$line" =~ ^# ]]; then
 				true # comment line
-			elif echo "$AST" | xmllint --xpath "${line}" - 2>/dev/null > /dev/null; then
-				((currentPasses=currentPasses+1))
-			else
+			elif echo "$AST" | xmllint --xpath "${line}" - 2>&1 | grep 'XPath set is empty' >/dev/null; then
 				echo
 				echo -e "    ${RED}Check on line $lineCount of $queryFile failed.${NORMAL}"
 				((currentFailures=currentFailures+1))
+			else
+				((currentPasses=currentPasses+1))
 			fi
 			((lineCount=lineCount+1))
 		done < "$queryFile"


### PR DESCRIPTION
better implementation, doing all the tokenizing at the start, an interpolated string being multiple tokens

requires no further changes in DCD to support with auto-completion, probably also going to just work with D-Scanner and serve-d

supersedes #508 

implementation for [DIP1036e](https://github.com/dlang/dmd/pull/15715)
