### PR TITLE
Fix shortened FunctionBody and comment formatting

### DIFF
--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -1178,7 +1178,7 @@ class Formatter(Sink)
             if (member.comment.length)
             {
                 space();
-                put(member.comment);
+                putComment(member.comment);
             }
         }
         endBlock();
@@ -1497,6 +1497,7 @@ class Formatter(Sink)
         with(functionBody)
         {
             if (specifiedFunctionBody) format(specifiedFunctionBody);
+            if (shortenedFunctionBody) format(shortenedFunctionBody);
             if (missingFunctionBody) format(missingFunctionBody);
         }
     }
@@ -4000,7 +4001,7 @@ protected:
     {
         import std.string : splitLines;
         if (!c.length) return;
-        put(c.splitLines().join("\n" ~ getIndent()));
+        put(c.splitLines().map!((x) => "/// " ~ x).join("\n" ~ getIndent()));
         newlineIndent();
     }
 

--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -2691,7 +2691,7 @@ class Formatter(Sink)
     void format(const ShortenedFunctionBody shortenedFunctionBody)
     {
         debug(verbose) writeln("ShortenedFunctionBody");
-        put("=> ");
+        put(" => ");
         format(shortenedFunctionBody.expression);
         put(";");
     }
@@ -4349,4 +4349,22 @@ do
     {
     }
 }}, `a == b && c == d`);
+    testFormatNode!(FunctionDeclaration)(q{void foo() => writeln("Hello");});
+    testFormatNode!(VariableDeclaration)(q{/// Documentation for this variable
+/// which is even multilined.
+int x;});
+    testFormatNode!(EnumDeclaration)(q{enum Foo {
+        x, /// Documentation for x
+        y, /// Documentation for y
+        z, /// Documentation for z
+}}, "enum Foo 
+
+{
+x, /// Documentation for x
+    
+y, /// Documentation for y
+    
+z /// Documentation for z
+    
+}");
 }


### PR DESCRIPTION
Nothing major, but the comment formatting produced invalid code since the three slashes at the beginning weren't written. Additionally, a shortened function body (`=>`) now also appears in formatting.