### PR TITLE
Fix NamedtemplateArgumentList documentation

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -6954,7 +6954,7 @@ class Parser
     /**
      * Parses a NamedTemplateArgumentList
      *
-     * $(GRAMMAR $(RULEDEF templateArgumentList):
+     * $(GRAMMAR $(RULEDEF namedTemplateArgumentList):
      *     $(RULE namedTemplateArgument) ($(LITERAL ',') $(RULE namedTemplateArgument)?)*
      *     ;)
      */


### PR DESCRIPTION
Just a quick fix in the D grammar documentation