### PR TITLE
fix grammar documentation generation

### DIFF
--- a/src/dparse/lexer.d
+++ b/src/dparse/lexer.d
@@ -244,9 +244,9 @@ private immutable extraFieldsBare = q{
         import std.conv : to;
         import dparse.lexer : str;
 
-        sink.put("trivia!\"");
+        sink.put(`trivia!"`);
         sink.put(str(type));
-        sink.put("\"(");
+        sink.put(`"(`);
         sink.put("text: ");
         sink.put([text].to!string[1 .. $ - 1]); // escape hack
         sink.put(", index: ");


### PR DESCRIPTION
This issue comes from ddox tokenizer that seems to have a bug when escaped quotes appear in [token strings](https://dlang.org/spec/lex.html#token_strings).

I guess a long-term solution would be to report and fix the bug directly in ddox