### PR TITLE
Upgrade upload-artifact action to v4

### DIFF
--- a/.github/workflows/pr_info_untrusted.yml
+++ b/.github/workflows/pr_info_untrusted.yml
@@ -58,7 +58,7 @@ jobs:
         echo ${{ github.event.number }} > ./pr/NR
 
     - name: upload comment to high-trust action making the comment
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pr
         path: pr/


### PR DESCRIPTION
The previously-used v2 is deprecated, and using it was causing the workflow to fail.