### PR TITLE
Avoid incrementing an rvalue

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -8888,7 +8888,8 @@ protected: final:
             else
                 import std.experimental.checkedint;
 
-            ++suppressMessages.back.checked;
+            auto ci = suppressMessages.back.checked;
+            suppressMessages.back = (ci + 1).get;
         }
         while (shouldAdvance && moreTokens())
         {


### PR DESCRIPTION
Original change is here: https://github.com/dlang-community/libdparse/commit/011309a73f51ce2febd3e0cabb3ffdf1ff1f41d0#r163931943