### PR TITLE
Allow keywords as identifiers in extern(C) blocks for better C interopability

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -5532,7 +5532,7 @@ class Parser
 
         ownArray(node.parameterAttributes, parameterAttributes);
         mixin(parseNodeQ!(`node.type`, `Type`));
-        if (currentIs(tok!"identifier"))
+        if (currentIs(tok!"identifier") || (isInExternC() && isKeyword(current.type)))
         {
             node.name = advance();
             if (currentIs(tok!"..."))

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -2303,7 +2303,7 @@ class Parser
             warn("Empty declaration");
             advance();
             break;
-    case tok!"{":
+        case tok!"{":
         if (node.attributes.empty)
         {
             error("declaration expected instead of `{`");

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -118,6 +118,16 @@ Module parseModule(F)(const(Token)[] tokens, string fileName, RollbackAllocator*
  */
 class Parser
 {
+    /// Is it a interface file for a C source code
+    bool importC;
+    /// Depth of extern(C) blocks we're currently inside
+    int externCDepth;
+
+    bool isInExternC() const pure nothrow @safe @nogc
+    {
+        return importC || externCDepth > 0;
+    }
+
     /**
      * Parses an AddExpression.
      *
@@ -2293,27 +2303,44 @@ class Parser
             warn("Empty declaration");
             advance();
             break;
-        case tok!"{":
-            if (node.attributes.empty)
+    case tok!"{":
+        if (node.attributes.empty)
+        {
+            error("declaration expected instead of `{`");
+            return null;
+        }
+        // Check if we're in an extern(C) block
+        bool isExternC = false;
+        foreach (attr; node.attributes)
+        {
+            if (attr.linkageAttribute !is null &&
+                attr.linkageAttribute.identifier.text == "C")
             {
-                error("declaration expected instead of `{`");
+                isExternC = true;
+                break;
+            }
+        }
+        if (isExternC)
+            externCDepth++;
+        advance();
+        alias declarations = attributes;
+        declarations.clear();
+        while (moreTokens() && !currentIs(tok!"}"))
+        {
+            auto c = allocator.setCheckpoint();
+            if (!declarations.put(parseDeclaration(strict, false, inTemplateDeclaration)))
+            {
+                allocator.rollback(c);
+                if (isExternC)
+                    externCDepth--;
                 return null;
             }
-            advance();
-            alias declarations = attributes;
-            declarations.clear();
-            while (moreTokens() && !currentIs(tok!"}"))
-            {
-                auto c = allocator.setCheckpoint();
-                if (!declarations.put(parseDeclaration(strict, false, inTemplateDeclaration)))
-                {
-                    allocator.rollback(c);
-                    return null;
-                }
-            }
-            ownArray(node.declarations, declarations);
-            mixin(tokenCheck!"}");
-            break;
+        }
+        if (isExternC)
+            externCDepth--;
+        ownArray(node.declarations, declarations);
+        mixin(tokenCheck!"}");
+        break;
         case tok!"alias":
             if (startsWith(tok!"alias", tok!"identifier", tok!"this"))
                 mixin(parseNodeQ!(`node.aliasThisDeclaration`, `AliasThisDeclaration`));
@@ -2481,7 +2508,7 @@ class Parser
         foreach (B; BasicTypes) { case B: }
         type:
             Type t = parseType();
-            if (t is null || !currentIsOneOf(tok!"identifier", tok!":"))
+            if (t is null || !(currentIs(tok!"identifier") || (isInExternC() && isKeyword(current.type)) || currentIs(tok!":")))
             {
                 if (t)
                     error("no identifier for declarator");
@@ -2654,7 +2681,17 @@ class Parser
         }
         else
         {
-            const id = expect(tok!"identifier");
+            const(Token)* id;
+            if (currentIs(tok!"identifier") || (isInExternC() && isKeyword(current.type)))
+                id = &tokens[index++];
+            else
+            {
+                error("Expected identifier instead of " ~ (index < tokens.length
+                    ? (tokens[index].text is null ? "`" ~ str(tokens[index].type) ~ "`"
+                       : str(tokens[index].type) ~ " `" ~ tokens[index].text ~ "`")
+                    : "EOF"));
+                return null;
+            }
             mixin (nullCheck!`id`);
             node.name = *id;
             if (currentIs(tok!"[")) // dmd doesn't accept pointer after identifier

--- a/test/tester.d
+++ b/test/tester.d
@@ -313,56 +313,63 @@ void testArbitraryASTs()
     parser.messageDelegate = &msgDelegate;
     parser.allocator = &rba;
 
-    parser.tokens = getTokensForParser("struct S {}", config, &cache);
-    assert(parser.parseCompileCondition() is null);
-    assert(errors == ["`version`, `debug`, or `static` expected (found token `struct`)"]);
-    errors = null;
-
-    parser = new Parser();
-    parser.messageDelegate = &msgDelegate;
-    parser.allocator = &rba;
-    parser.tokens = getTokensForParser("~", config, &cache);
-    assert(parser.parseDestructor() is null);
-    assert(errors == ["`this` expected instead of EOF"]);
-    errors = null;
-
-    parser = new Parser();
-    parser.messageDelegate = &msgDelegate;
-    parser.allocator = &rba;
-    parser.tokens = getTokensForParser("for (x; y; z) {}", config, &cache);
-    assert(parser.parseForeach() is null);
-    assert(errors == ["`foreach` or `foreach_reverse` expected (found token `for`)"]);
-    errors = null;
-
-    parser = new Parser();
-    parser.messageDelegate = &msgDelegate;
-    parser.allocator = &rba;
-    parser.tokens = getTokensForParser("version =", config, &cache);
-    assert(parser.parseVersionSpecification() is null);
-    assert(errors == ["Identifier or integer literal expected (found EOF)"]);
-    errors = null;
-
-    parser = new Parser();
-    parser.messageDelegate = &msgDelegate;
-    parser.allocator = &rba;
-    parser.importC = false;
-    parser.tokens = getTokensForParser("extern(C) { int normal = 1; int true = 1; }", config, &cache);
-    assert(parser.parseAttribute() !is null);
-    auto b = parser.parseBlockStatement();
-    assert(b !is null);
-    assert(b.declarationsAndStatements.declarationsAndStatements.length == 1);
-    errors = null;
-
-    parser = new Parser();
-    parser.messageDelegate = &msgDelegate;
-    parser.allocator = &rba;
-    parser.importC = true;
-    parser.tokens = getTokensForParser("extern(C) { int normal = 1; int true = 1; }", config, &cache);
-    assert(parser.parseAttribute() !is null);
-    auto b = parser.parseBlockStatement();
-    assert(b !is null);
-    assert(b.declarationsAndStatements.declarationsAndStatements.length == 2);
-    errors = null;
+    {
+        parser.tokens = getTokensForParser("struct S {}", config, &cache);
+        assert(parser.parseCompileCondition() is null);
+        assert(errors == ["`version`, `debug`, or `static` expected (found token `struct`)"]);
+        errors = null;
+    }
+    {
+        parser = new Parser();
+        parser.messageDelegate = &msgDelegate;
+        parser.allocator = &rba;
+        parser.tokens = getTokensForParser("~", config, &cache);
+        assert(parser.parseDestructor() is null);
+        assert(errors == ["`this` expected instead of EOF"]);
+        errors = null;
+    }
+    {
+        parser = new Parser();
+        parser.messageDelegate = &msgDelegate;
+        parser.allocator = &rba;
+        parser.tokens = getTokensForParser("for (x; y; z) {}", config, &cache);
+        assert(parser.parseForeach() is null);
+        assert(errors == ["`foreach` or `foreach_reverse` expected (found token `for`)"]);
+        errors = null;
+    }
+    {
+        parser = new Parser();
+        parser.messageDelegate = &msgDelegate;
+        parser.allocator = &rba;
+        parser.tokens = getTokensForParser("version =", config, &cache);
+        assert(parser.parseVersionSpecification() is null);
+        assert(errors == ["Identifier or integer literal expected (found EOF)"]);
+        errors = null;
+    }
+    {
+        parser = new Parser();
+        parser.messageDelegate = &msgDelegate;
+        parser.allocator = &rba;
+        parser.importC = false;
+        parser.tokens = getTokensForParser("extern(C) { int normal = 1; int true = 1; }", config, &cache);
+        assert(parser.parseAttribute() !is null);
+        auto b = parser.parseBlockStatement();
+        assert(b !is null);
+        assert(b.declarationsAndStatements.declarationsAndStatements.length == 1);
+        errors = null;
+    }
+    {
+        parser = new Parser();
+        parser.messageDelegate = &msgDelegate;
+        parser.allocator = &rba;
+        parser.importC = true;
+        parser.tokens = getTokensForParser("extern(C) { int normal = 1; int true = 1; }", config, &cache);
+        assert(parser.parseAttribute() !is null);
+        auto b = parser.parseBlockStatement();
+        assert(b !is null);
+        assert(b.declarationsAndStatements.declarationsAndStatements.length == 2);
+        errors = null;
+    }
 
 }
 

--- a/test/tester.d
+++ b/test/tester.d
@@ -342,6 +342,28 @@ void testArbitraryASTs()
     assert(errors == ["Identifier or integer literal expected (found EOF)"]);
     errors = null;
 
+    parser = new Parser();
+    parser.messageDelegate = &msgDelegate;
+    parser.allocator = &rba;
+    parser.importC = false;
+    parser.tokens = getTokensForParser("extern(C) { int normal = 1; int true = 1; }", config, &cache);
+    assert(parser.parseAttribute() !is null);
+    auto b = parser.parseBlockStatement();
+    assert(b !is null);
+    assert(b.declarationsAndStatements.declarationsAndStatements.length == 1);
+    errors = null;
+
+    parser = new Parser();
+    parser.messageDelegate = &msgDelegate;
+    parser.allocator = &rba;
+    parser.importC = true;
+    parser.tokens = getTokensForParser("extern(C) { int normal = 1; int true = 1; }", config, &cache);
+    assert(parser.parseAttribute() !is null);
+    auto b = parser.parseBlockStatement();
+    assert(b !is null);
+    assert(b.declarationsAndStatements.declarationsAndStatements.length == 2);
+    errors = null;
+
 }
 
 int main(string[] args)


### PR DESCRIPTION
-Hf ouputs all symbols inside a `extern(C) {}` for ImportC

libdparse struggle with that if one of the symbol's identifier is a reserved keyword

This PR introduces a new config option for the Parser, `bool importC`, if set to true it'll relax the rule to allow keywords to be used as identifier, so it can proceed in parsing the whole `extern(C) {}` block properly